### PR TITLE
Closing #3 : 3rdparty scripts fixes

### DIFF
--- a/bash/install-3rdparty-linux-ubuntu-14.04.sh
+++ b/bash/install-3rdparty-linux-ubuntu-14.04.sh
@@ -30,7 +30,6 @@ function valid()
   fi
 }
 
-
 #
 # Check for tws-3rdparty-macosx-el-capitan.tar.gz
 #
@@ -59,6 +58,31 @@ sleep 1s
 cd eows-3rdparty-0.3.0-linux-ubuntu-14.04
 valid $? "Error: could not enter 'eows-3rdparty-0.3.0-linux-ubuntu-14.04' dir"
 
+#
+# Check for cmake 3.7.2
+#
+if [ ! -f ./cmake-3.7.2.tar.gz ]; then
+  wget -O cmake-3.7.2.tar.gz https://cmake.org/files/v3.7/cmake-3.7.2.tar.gz
+  valid $? "Error: Could not download cmake 3.7.2"
+fi
+
+#
+# Qt5 (Required for CMake GUI)
+#
+sudo apt-get -y install qt5-default qttools5-dev qttools5-dev-tools libqt5svg5-dev libqt5designer5
+
+#
+# Installing CMake
+#
+cmake_expr_test=`cmake --version | awk 'NR==1{print $3}'` # Retrieving values only first line and third column
+if [ "$cmake_expr_test" != "3.7.2" ]; then
+  tar zxf cmake-3.7.2.tar.gz
+  valid $? "Could not extract CMake 3.7.2 tar.gz"
+  cd cmake-3.7.2
+  ./configure --qt-gui
+  make
+  sudo make install
+fi
 
 #
 # Check installation dir
@@ -121,10 +145,10 @@ if [ ! -f "$EOWS_LIBS_DIR/include/rapidjson/rapidjson.h" ]; then
   echo "installing RapidJSON..."
   sleep 1s
   
-  unzip rapidjson-1.1.0.zip
+  unzip -o rapidjson-1.1.0.zip
   valid $? "Error: RapidJSON!"
 
-  mkdir rapidjson-build
+  mkdir -p rapidjson-build
   valid $? "Error: RapidJSON!"
 
   cd rapidjson-build
@@ -154,7 +178,7 @@ if [ ! -f "$EOWS_LIBS_DIR/include/rapidxml/rapidxml.hpp" ]; then
   echo "installing RapidXML..."
   sleep 1s
 
-  unzip rapidxml-1.13.zip
+  unzip -o rapidxml-1.13.zip
   valid $? "Error: RapidXML!"
 
   mv rapidxml-1.13 $EOWS_LIBS_DIR/include/rapidxml
@@ -170,7 +194,7 @@ if [ ! -f "$EOWS_LIBS_DIR/include/crow_all.h" ]; then
   echo "installing Crow..."
   sleep 1s
 
-  unzip crow-master.zip
+  unzip -o crow-master.zip
   valid $? "Error: Crow!"
 
   cp crow-master/amalgamate/crow_all.h $EOWS_LIBS_DIR/include/

--- a/bash/install-3rdparty-linux-ubuntu-14.04.sh
+++ b/bash/install-3rdparty-linux-ubuntu-14.04.sh
@@ -82,6 +82,8 @@ if [ "$cmake_expr_test" != "3.7.2" ]; then
   ./configure --qt-gui
   make
   sudo make install
+
+  cd ..
 fi
 
 #

--- a/bash/install-3rdparty-linux-ubuntu-14.04.sh
+++ b/bash/install-3rdparty-linux-ubuntu-14.04.sh
@@ -59,34 +59,6 @@ cd eows-3rdparty-0.3.0-linux-ubuntu-14.04
 valid $? "Error: could not enter 'eows-3rdparty-0.3.0-linux-ubuntu-14.04' dir"
 
 #
-# Check for cmake 3.7.2
-#
-if [ ! -f ./cmake-3.7.2.tar.gz ]; then
-  wget -O cmake-3.7.2.tar.gz https://cmake.org/files/v3.7/cmake-3.7.2.tar.gz
-  valid $? "Error: Could not download cmake 3.7.2"
-fi
-
-#
-# Qt5 (Required for CMake GUI)
-#
-sudo apt-get -y install qt5-default qttools5-dev qttools5-dev-tools libqt5svg5-dev libqt5designer5
-
-#
-# Installing CMake
-#
-cmake_expr_test=`cmake --version | awk 'NR==1{print $3}'` # Retrieving values only first line and third column
-if [ "$cmake_expr_test" != "3.7.2" ]; then
-  tar zxf cmake-3.7.2.tar.gz
-  valid $? "Could not extract CMake 3.7.2 tar.gz"
-  cd cmake-3.7.2
-  ./configure --qt-gui
-  make
-  sudo make install
-
-  cd ..
-fi
-
-#
 # Check installation dir
 #
 if [ "$EOWS_LIBS_DIR" == "" ]; then
@@ -98,6 +70,17 @@ export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$EOWS_LIBS_DIR/lib"
 echo "installing 3rd-party libraries to '$EOWS_LIBS_DIR' ..."
 sleep 1s
 
+
+#
+# Check CMake version. EOWS requires 3.x
+#
+cmake_ver_test=`cmake --version | awk 'NR==1{print substr($3,0,2)}'`
+cmake_curr_ver=`cmake --version | awk 'NR==1{print $3}'`
+if [ $cmake_ver_test -le 2 ]; then
+  valid 1 "Error: EOWS requires CMake >= 3.x version but $cmake_curr_ver found. Please install CMake 3.x."
+else
+  echo "CMake installation ok. Version $cmake_curr_ver > 2.X"
+fi
 
 #
 # OpenSSL


### PR DESCRIPTION
Ticket #3

When using native cmake ubuntu 14.04 LTS (2.8.12), the process compilation does not working. Only using CMake 3.X. In this way, the script download cmake 3.7.2 source and compile it. (Required qt5 for cmake-gui)

(cherry picked from commit 00859f061a2631e403d0528cae221f833abbdcdf)