### PR TITLE
Adding WCS 2.0 GetCapabilities support

### DIFF
--- a/bash/install-3rdparty-linux-ubuntu-14.04.sh
+++ b/bash/install-3rdparty-linux-ubuntu-14.04.sh
@@ -82,6 +82,7 @@ if [ "$cmake_expr_test" != "3.7.2" ]; then
   ./configure --qt-gui
   make
   sudo make install
+  cd ..
 fi
 
 #

--- a/bash/install-3rdparty-linux-ubuntu-14.04.sh
+++ b/bash/install-3rdparty-linux-ubuntu-14.04.sh
@@ -30,7 +30,6 @@ function valid()
   fi
 }
 
-
 #
 # Check for tws-3rdparty-macosx-el-capitan.tar.gz
 #
@@ -59,6 +58,31 @@ sleep 1s
 cd eows-3rdparty-0.3.0-linux-ubuntu-14.04
 valid $? "Error: could not enter 'eows-3rdparty-0.3.0-linux-ubuntu-14.04' dir"
 
+#
+# Check for cmake 3.7.2
+#
+if [ ! -f ./cmake-3.7.2.tar.gz ]; then
+  wget -O cmake-3.7.2.tar.gz https://cmake.org/files/v3.7/cmake-3.7.2.tar.gz
+  valid $? "Error: Could not download cmake 3.7.2"
+fi
+
+#
+# Qt5 (Required for CMake GUI)
+#
+sudo apt-get -y install qt5-default qttools5-dev qttools5-dev-tools libqt5svg5-dev libqt5designer5
+
+#
+# Installing CMake
+#
+cmake_expr_test=`cmake --version | awk 'NR==1{print $3}'` # Retrieving values only first line and third column
+if [ "$cmake_expr_test" != "3.7.2" ]; then
+  tar zxf cmake-3.7.2.tar.gz
+  valid $? "Could not extract CMake 3.7.2 tar.gz"
+  cd cmake-3.7.2
+  ./configure --qt-gui
+  make
+  sudo make install
+fi
 
 #
 # Check installation dir
@@ -121,10 +145,10 @@ if [ ! -f "$EOWS_LIBS_DIR/include/rapidjson/rapidjson.h" ]; then
   echo "installing RapidJSON..."
   sleep 1s
   
-  unzip rapidjson-1.1.0.zip
+  unzip -o rapidjson-1.1.0.zip
   valid $? "Error: RapidJSON!"
 
-  mkdir rapidjson-build
+  mkdir -p rapidjson-build
   valid $? "Error: RapidJSON!"
 
   cd rapidjson-build
@@ -154,7 +178,7 @@ if [ ! -f "$EOWS_LIBS_DIR/include/rapidxml/rapidxml.hpp" ]; then
   echo "installing RapidXML..."
   sleep 1s
 
-  unzip rapidxml-1.13.zip
+  unzip -o rapidxml-1.13.zip
   valid $? "Error: RapidXML!"
 
   mv rapidxml-1.13 $EOWS_LIBS_DIR/include/rapidxml
@@ -170,7 +194,7 @@ if [ ! -f "$EOWS_LIBS_DIR/include/crow_all.h" ]; then
   echo "installing Crow..."
   sleep 1s
 
-  unzip crow-master.zip
+  unzip -o crow-master.zip
   valid $? "Error: Crow!"
 
   cp crow-master/amalgamate/crow_all.h $EOWS_LIBS_DIR/include/

--- a/build/cmake/wcs/CMakeLists.txt
+++ b/build/cmake/wcs/CMakeLists.txt
@@ -1,5 +1,5 @@
-file(GLOB EOWS_SRC_FILES ${EOWS_ABSOLUTE_ROOT_DIR}/src/eows/ogc/wcs/*.cpp)
-file(GLOB EOWS_HDR_FILES ${EOWS_ABSOLUTE_ROOT_DIR}/src/eows/ogc/wcs/*.hpp)
+file(GLOB_RECURSE EOWS_SRC_FILES ${EOWS_ABSOLUTE_ROOT_DIR}/src/eows/ogc/wcs/*.cpp)
+file(GLOB_RECURSE EOWS_HDR_FILES ${EOWS_ABSOLUTE_ROOT_DIR}/src/eows/ogc/wcs/*.hpp)
 
 source_group("Source Files"  FILES ${EOWS_SRC_FILES})
 source_group("Header Files"  FILES ${EOWS_HDR_FILES})

--- a/share/eows/config/eows.json
+++ b/share/eows/config/eows.json
@@ -1,5 +1,5 @@
 {
-  "log_file": "/home/gribeiro/eows/log/eows_%Y-%m-%d_%H-%M-%S.%N.log",
+  "log_file": "$HOME/eows/log/eows_%Y-%m-%d_%H-%M-%S.%N.log",
   "http_server": "crow",
   "scidb_clusters": [
     {

--- a/share/eows/config/wcs.json
+++ b/share/eows/config/wcs.json
@@ -1,0 +1,68 @@
+{
+  "WCSCapabilities": {
+    "ServiceIdentification": {
+      "Title": "e-Sensing Web Coverage Service",
+      "Abstract": "Web Coverage Service maintained by the e-Sensing team",
+      "OnlineResource": "http://www.esensing.org",
+      "ServiceType": "OGC WCS",
+      "ServiceTypeVersion": "2.0.1",
+      "Profiles": []
+    },
+    "ServiceProvider": {
+      "ProviderName": "National Institute for Spatial Research",
+      "ProviderSite": "http://www.dpi.inpe.br",
+      "ServiceContact": {
+        "IndividualName": "Gilberto Queiroz",
+        "PositionName": "Computer Scientist",
+        "ContactInfo": {
+          "AddressType": "postal",
+          "Address": "Av. Astronautas, 1758",
+          "City": "São José dos Campos",
+          "StateOrProvince": "SP",
+          "PostCode": "12227-010",
+          "Country": "Brazil"
+        },
+        "ContactVoiceTelephone": "3208",
+        "ContactFacsimileTelephone": "3209",
+        "ContactEletronicMailAddress": "gribeiro"
+      }
+    },
+    "OperationsMetadata": [
+      {
+        "name": "GetCapabilities",
+        "DCP": {
+          "HTTP": {
+            "GET": "http://localhost:7654/wcs"
+          }
+        } 
+      },
+      {
+        "name": "DescribeCoverage",
+        "DCP": {
+          "HTTP": {
+            "GET": "http://localhost:7654/wcs"
+          }
+        } 
+      },
+      {
+        "name": "GetCoverage",
+        "DCP": {
+          "HTTP": {
+            "GET": "http://localhost:7654/wcs"
+          }
+        } 
+      }
+    ],
+    "ServiceMetadata": {
+      "formatSupported": ["application/gml+xml"]
+    },
+    "Contents": [
+      {
+        "CoverageSummary": {
+          "id": "mod09q1",
+          "subtype": "GridCoverage"
+        }
+      }
+    ]
+  }
+}

--- a/src/eows/core/defines.hpp
+++ b/src/eows/core/defines.hpp
@@ -36,4 +36,6 @@
 
 #define  EOWS_WMS_FILE "share/eows/config/wms.json"
 
+#define  EOWS_WCS_FILE "share/eows/config/wcs.json"
+
 #endif // __EOWS_CORE_LOGGER_HPP__

--- a/src/eows/exception.hpp
+++ b/src/eows/exception.hpp
@@ -44,7 +44,7 @@ namespace eows
     explicit parse_error(const char* s) : std::runtime_error(s) {}
   };
 
-  struct eows_error : virtual std::runtime_error
+  struct eows_error : public std::runtime_error
   {
     explicit eows_error(const std::string& s) : std::runtime_error(s) {}
     explicit eows_error(const char* s) : std::runtime_error(s) {}

--- a/src/eows/exception.hpp
+++ b/src/eows/exception.hpp
@@ -44,6 +44,12 @@ namespace eows
     explicit parse_error(const char* s) : std::runtime_error(s) {}
   };
 
+  struct eows_error : virtual std::runtime_error
+  {
+    explicit eows_error(const std::string& s) : std::runtime_error(s) {}
+    explicit eows_error(const char* s) : std::runtime_error(s) {}
+  };
+
 }   // end namespace eows
 
 #endif // __EOWS_EXCEPTION_HPP__

--- a/src/eows/ogc/exception.hpp
+++ b/src/eows/ogc/exception.hpp
@@ -41,13 +41,18 @@ namespace eows
      */
     struct ogc_error : public eows_error
     {
-      explicit ogc_error(const std::string& s, const std::string& c) : eows_error(s) {
+      explicit ogc_error(const std::string& s, const std::string& c)
+        : eows_error(s)
+      {
         error_code = c;
       }
-      explicit ogc_error(const char*& s, const std::string& c) : eows_error(s), error_code(c) {}
+      explicit ogc_error(const char*& s, const std::string& c)
+        : eows_error(s), error_code(c) {}
 
       //! Defines code error useful during exception handling
       std::string error_code;
+      //! Defines value user typed during OGC request
+      std::string locator;
     };
 
     /**

--- a/src/eows/ogc/exception.hpp
+++ b/src/eows/ogc/exception.hpp
@@ -41,8 +41,13 @@ namespace eows
      */
     struct ogc_error : public eows_error
     {
-      explicit ogc_error(const std::string& s) : eows_error(s) {}
-      explicit ogc_error(const char*& s) : eows_error(s) {}
+      explicit ogc_error(const std::string& s, const std::string& c) : eows_error(s) {
+        error_code = c;
+      }
+      explicit ogc_error(const char*& s, const std::string& c) : eows_error(s), error_code(c) {}
+
+      //! Defines code error useful during exception handling
+      std::string error_code;
     };
 
     /**
@@ -50,8 +55,17 @@ namespace eows
      */
     struct missing_parameter_error : public virtual ogc_error
     {
-      explicit missing_parameter_error(const std::string& s) : ogc_error(s) { }
-      explicit missing_parameter_error(const char* s) : ogc_error(s) { }
+      explicit missing_parameter_error(const std::string& s, const std::string& code) : ogc_error(s, code) { }
+      explicit missing_parameter_error(const char* s, const std::string& code) : ogc_error(s, code) { }
+    };
+
+    /**
+     * @brief Used when user gives parameter, but it seems inconsistent or invalid
+     */
+    struct invalid_parameter_error : public virtual ogc_error
+    {
+      explicit invalid_parameter_error(const std::string& s, const std::string& code) : ogc_error(s, code) { }
+      explicit invalid_parameter_error(const char* s, const std::string& code) : ogc_error(s, code) { }
     };
 
     /**
@@ -59,8 +73,17 @@ namespace eows
      */
     struct not_implemented_error : public virtual ogc_error
     {
-      explicit not_implemented_error(const std::string& s) : ogc_error(s) { }
-      explicit not_implemented_error(const char* s) : ogc_error(s) { }
+      explicit not_implemented_error(const std::string& s, const std::string& code) : ogc_error(s, code) { }
+      explicit not_implemented_error(const char* s, const std::string& code) : ogc_error(s, code) { }
+    };
+
+    /**
+     * @brief Used when a function or operation is not currently supported
+     */
+    struct not_supported_error : public virtual ogc_error
+    {
+      explicit not_supported_error(const std::string& s, const std::string& code) : ogc_error(s, code) { }
+      explicit not_supported_error(const char* s, const std::string& code) : ogc_error(s, code) { }
     };
   }  // end namespace ogc
 }    // end namespace eows

--- a/src/eows/ogc/exception.hpp
+++ b/src/eows/ogc/exception.hpp
@@ -36,8 +36,15 @@ namespace eows
   //! The namespace for the OGC Runtime module of EOWS.
   namespace ogc
   {
+    struct ogc_error : virtual eows_error { };
 
+    struct missing_parameter_error : virtual std::runtime_error {
+      explicit missing_parameter_error(const std::string& s) : std::runtime_error(s) {}
+    };
 
+    struct not_implemented_error : virtual std::runtime_error {
+      explicit not_implemented_error(const std::string& s) : std::runtime_error(s) {}
+    };
   }  // end namespace ogc
 }    // end namespace eows
 

--- a/src/eows/ogc/exception.hpp
+++ b/src/eows/ogc/exception.hpp
@@ -36,14 +36,31 @@ namespace eows
   //! The namespace for the OGC Runtime module of EOWS.
   namespace ogc
   {
-    struct ogc_error : virtual eows_error { };
-
-    struct missing_parameter_error : virtual std::runtime_error {
-      explicit missing_parameter_error(const std::string& s) : std::runtime_error(s) {}
+    /**
+     * @brief Generic error for OGC service
+     */
+    struct ogc_error : public eows_error
+    {
+      explicit ogc_error(const std::string& s) : eows_error(s) {}
+      explicit ogc_error(const char*& s) : eows_error(s) {}
     };
 
-    struct not_implemented_error : virtual std::runtime_error {
-      explicit not_implemented_error(const std::string& s) : std::runtime_error(s) {}
+    /**
+     * @brief Used when user misses required parameter(s) on OGC service.
+     */
+    struct missing_parameter_error : public virtual ogc_error
+    {
+      explicit missing_parameter_error(const std::string& s) : ogc_error(s) { }
+      explicit missing_parameter_error(const char* s) : ogc_error(s) { }
+    };
+
+    /**
+     * @brief Used when a function or operation is not implemented on OGC service yet.
+     */
+    struct not_implemented_error : public virtual ogc_error
+    {
+      explicit not_implemented_error(const std::string& s) : ogc_error(s) { }
+      explicit not_implemented_error(const char* s) : ogc_error(s) { }
     };
   }  // end namespace ogc
 }    // end namespace eows

--- a/src/eows/ogc/wcs/core/data_types.hpp
+++ b/src/eows/ogc/wcs/core/data_types.hpp
@@ -1,0 +1,133 @@
+#ifndef __EOF_OGC_WCS_CORE_DATA_TYPES__
+#define __EOF_OGC_WCS_CORE_DATA_TYPES__
+
+// STL
+#include <string>
+#include <vector>
+
+namespace eows
+{
+  namespace ogc
+  {
+    namespace wcs
+    {
+      namespace core
+      {
+        /**
+         * @brief It defines a WCS online resource (Host link)
+         */
+        struct online_resource_t
+        {
+          std::string xlink;
+          std::string href;
+        };
+
+        /**
+         * @brief It represents a contact information based on WCS 2.0 spec
+         */
+        struct contact_person_primary_t
+        {
+          std::string contact_person;
+          std::string contact_organization;
+        };
+
+        /**
+         * @brief The represents contact information, defining who maintain the project, etc.
+         */
+        struct contact_address_t
+        {
+          std::string address_type;
+          std::string address;
+          std::string city;
+          std::string state_or_province;
+          std::string post_code;
+          std::string country;
+        };
+
+        /**
+         * @brief It represents a contact phone
+         * @todo Support every contact information
+         */
+        struct phone_t
+        {
+          std::string voice;
+        };
+
+        /**
+         * @brief It represents a contact ways (phone, email etc)
+         * @todo describe others types
+         */
+        struct contact_info_t
+        {
+          phone_t phone;
+        };
+
+        struct service_contact_t
+        {
+          std::string individual_name;
+          std::string position_name;
+          contact_info_t contact_info;
+        };
+
+        struct service_provider_t
+        {
+          std::string provider_name;
+          std::string provider_site;
+          service_contact_t service_contact;
+        };
+
+        struct service_identification_t
+        {
+          std::string title;
+          std::string abstract;
+          std::string service_type;
+          std::string service_type_version;
+          std::vector<std::string> profiles;
+        };
+
+        struct dcp_t
+        {
+          std::string get;
+        };
+
+        struct operation_t
+        {
+          std::string name;
+          dcp_t dcp;
+        };
+
+        struct operation_metadata_t
+        {
+          std::vector<operation_t> operations;
+        };
+
+        struct service_metadata_t
+        {
+          std::vector<std::string> formats_supported;
+        };
+
+        struct coverage_summary_t
+        {
+          std::string coverage_id;
+          std::string coverage_subtype;
+        };
+
+        struct content_t
+        {
+          std::vector<coverage_summary_t> summaries;
+        };
+
+        struct capabilities_t
+        {
+          service_identification_t service;
+          service_provider_t service_provider;
+          operation_metadata_t operation_metadata;
+          service_metadata_t service_metadata;
+          content_t content;
+        };
+      }
+    }
+  }
+}
+
+#endif

--- a/src/eows/ogc/wcs/core/operation.hpp
+++ b/src/eows/ogc/wcs/core/operation.hpp
@@ -1,0 +1,39 @@
+#ifndef __EOWS_OGC_WCS_CORE_OPERATIONS_HPP__
+#define __EOWS_OGC_WCS_CORE_OPERATIONS_HPP__
+
+#include <string>
+
+namespace eows
+{
+  namespace ogc
+  {
+    namespace wcs
+    {
+      namespace core
+      {
+        class operation
+        {
+          public:
+            operation()
+            {
+
+            }
+
+            virtual ~operation()
+            {
+            }
+
+            virtual const char* content_type() const = 0;
+
+            /**
+             * @brief It retrieves the raw operation output
+             * @returns string representation of operation
+             */
+            virtual const std::string to_string() const = 0;
+        };
+      }
+    }
+  }
+}
+
+#endif // __EOWS_OGC_WCS_CORE_OPERATIONS_HPP__

--- a/src/eows/ogc/wcs/core/operation.hpp
+++ b/src/eows/ogc/wcs/core/operation.hpp
@@ -11,6 +11,10 @@ namespace eows
     {
       namespace core
       {
+        /**
+         * @brief Represents a generic WCS operation skeleton. Once defined, you must implement required methods in order to
+         * determines execution behavior and even content type information
+         */
         class operation
         {
           public:
@@ -23,10 +27,20 @@ namespace eows
             {
             }
 
+            /**
+             * @brief It performs a WCS operation execution.
+             */
+            virtual void execute() = 0;
+
+            /**
+             * @brief It retrieves the content type used for this operation.
+             * @return
+             */
             virtual const char* content_type() const = 0;
 
             /**
-             * @brief It retrieves the raw operation output
+             * @brief It retrieves the raw operation output.
+             * @todo Review it. For operation like GetCoverage that processes raster information, the output is not a std string
              * @returns string representation of operation
              */
             virtual const std::string to_string() const = 0;

--- a/src/eows/ogc/wcs/core/operation.hpp
+++ b/src/eows/ogc/wcs/core/operation.hpp
@@ -1,3 +1,30 @@
+/*
+  Copyright (C) 2017 National Institute For Space Research (INPE) - Brazil.
+
+  This file is part of Earth Observation Web Services (EOWS).
+
+  EOWS is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License version 3 as
+  published by the Free Software Foundation.
+
+  EOWS is distributed  "AS-IS" in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY OF ANY KIND; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with EOWS. See LICENSE. If not, write to
+  e-sensing team at <esensing-team@dpi.inpe.br>.
+ */
+
+/*!
+  \file eows/ogc/wcs/core/operation.hpp
+
+  \brief Represents Generic WCS operation
+
+  \author Raphael Willian da Costa
+ */
+
 #ifndef __EOWS_OGC_WCS_CORE_OPERATIONS_HPP__
 #define __EOWS_OGC_WCS_CORE_OPERATIONS_HPP__
 

--- a/src/eows/ogc/wcs/core/utils.cpp
+++ b/src/eows/ogc/wcs/core/utils.cpp
@@ -2,6 +2,7 @@
 #include "data_types.hpp"
 #include "../exception.hpp"
 
+#include<algorithm>
 
 void eows::ogc::wcs::core::read(const rapidjson::Value& doc, capabilities_t& capability)
 {
@@ -124,4 +125,25 @@ void eows::ogc::wcs::core::read(const rapidjson::Value& jservice, eows::ogc::wcs
     coverage_summary.coverage_subtype = read_node_as_string(jit->value, "subtype");
     content.summaries.push_back(coverage_summary);
   }
+}
+
+std::map<std::string, std::string> eows::ogc::wcs::core::lowerify(const std::map<std::string, std::string>& given)
+{
+  std::map<std::string, std::string> out;
+
+  for(auto& it: given)
+  {
+    out.insert(std::pair<std::string, std::string>(to_lower(it.first), it.second));
+  }
+
+  return out;
+}
+
+std::string eows::ogc::wcs::core::to_lower(const std::string& str)
+{
+  std::string out;
+  out.resize(str.size());
+  std::transform(str.begin(), str.end(), out.begin(), ::tolower);
+
+  return out;
 }

--- a/src/eows/ogc/wcs/core/utils.cpp
+++ b/src/eows/ogc/wcs/core/utils.cpp
@@ -1,0 +1,127 @@
+#include "utils.hpp"
+#include "data_types.hpp"
+#include "../exception.hpp"
+
+
+void eows::ogc::wcs::core::read(const rapidjson::Value& doc, capabilities_t& capability)
+{
+  // Reading First Node "WCSCapabilities"
+  if(!doc.IsObject())
+    throw eows::parse_error("Key 'WCSCapabilities' must be a valid JSON object.");
+
+  // Reading WCS Service Identification
+  rapidjson::Value::ConstMemberIterator jit = doc.FindMember("ServiceIdentification");
+
+  if(jit == doc.MemberEnd())
+    throw eows::parse_error("Key 'ServiceIdentification' was not found in JSON document.");
+
+  read(jit->value, capability.service);
+
+  // Reading WCS Service Provider
+  jit = doc.FindMember("ServiceProvider");
+
+  if(jit == doc.MemberEnd())
+    throw eows::parse_error("Key 'ServiceProvider' was not found in JSON document.");
+
+  read(jit->value, capability.service_provider);
+
+  // Reading WCS Service Metadata
+  jit = doc.FindMember("ServiceMetadata");
+
+  if(jit == doc.MemberEnd())
+    throw eows::parse_error("Key 'ServiceMetadata' was not found in JSON document.");
+
+  read(jit->value, capability.service_metadata);
+
+  // Reading WCS Contents
+  jit = doc.FindMember("Contents");
+
+  if(jit == doc.MemberEnd())
+    throw eows::parse_error("Key 'Contents' was not found in JSON document.");
+
+  read(jit->value, capability.content);
+}
+
+void eows::ogc::wcs::core::read(const rapidjson::Value& jservice, eows::ogc::wcs::core::service_identification_t& service)
+{
+  // Validating ServiceIdentification structure (must be an object)
+  if(!jservice.IsObject())
+    throw eows::parse_error("Key 'ServiceIdentification' must be a valid JSON object.");
+
+  // Reading Elements
+  service.title = read_node_as_string(jservice, "Title");
+  service.abstract = read_node_as_string(jservice, "Abstract");
+  service.service_type = read_node_as_string(jservice, "ServiceType");
+  service.service_type_version = read_node_as_string(jservice, "ServiceTypeVersion");
+  // Reading KeyWords list
+  rapidjson::Value::ConstMemberIterator jit = jservice.FindMember("Profiles");
+  // TODO: auto format function in common
+  if((jit == jservice.MemberEnd()) || (!jit->value.IsArray()))
+    throw eows::parse_error("Please, check the key 'Profiles' in JSON document.");
+
+  for(auto& v: jit->value.GetArray())
+    service.profiles.push_back(v.GetString());
+}
+
+void eows::ogc::wcs::core::read(const rapidjson::Value& jservice, eows::ogc::wcs::core::service_provider_t& provider)
+{
+  // Validating ServiceProvider structure (must be an object)
+  if(!jservice.IsObject())
+    throw eows::parse_error("Key 'ServiceProvider' must be a valid JSON object.");
+
+  // Reading Elements
+  provider.provider_name = read_node_as_string(jservice, "ProviderName");
+  provider.provider_site = read_node_as_string(jservice, "ProviderSite");
+
+  rapidjson::Value::ConstMemberIterator contact_it = jservice.FindMember("ServiceContact");
+  if (contact_it == jservice.MemberEnd())
+    throw eows::parse_error("Key 'ServiceContact' were not found in JSON document");
+
+  if (!contact_it->value.IsObject())
+    throw eows::parse_error("Key 'ServiceContact' is not a JSON object");
+
+//  rapidjson::Value::ConstMemberIterator it = jservice.FindMember("ServiceContact");
+
+  provider.service_contact.individual_name = read_node_as_string(contact_it->value, "IndividualName");
+  provider.service_contact.position_name = read_node_as_string(contact_it->value, "PositionName");
+}
+
+const std::string eows::ogc::wcs::core::read_node_as_string(const rapidjson::Value& node, const std::string& memberName)
+{
+  rapidjson::Value::ConstMemberIterator jit = node.FindMember(memberName.c_str());
+  // TODO: auto format function in common
+  if((jit == node.MemberEnd()) || (!jit->value.IsString()))
+    throw eows::parse_error("Please, check the key " + memberName + " in JSON document.");
+  return jit->value.GetString();
+}
+
+void eows::ogc::wcs::core::read(const rapidjson::Value& jservice, eows::ogc::wcs::core::service_metadata_t& metadata)
+{
+  // Validating ServiceProvider structure (must be an object)
+  if(!jservice.IsObject())
+    throw eows::parse_error("Key 'ServiceMetadata' must be a valid JSON object.");
+
+  rapidjson::Value::ConstMemberIterator jit = jservice.FindMember("formatSupported");
+  if((jit == jservice.MemberEnd() || !jit->value.IsArray()))
+    throw eows::parse_error("Key 'ServiceMetadata' must be a array.");
+
+  for(auto& format: jit->value.GetArray())
+    metadata.formats_supported.push_back(format.GetString());
+}
+
+void eows::ogc::wcs::core::read(const rapidjson::Value& jservice, eows::ogc::wcs::core::content_t& content)
+{
+  // Validating ServiceProvider structure (must be an object)
+  if(!jservice.IsArray())
+    throw eows::parse_error("Key 'Contents' must be a valid JSON Array.");
+
+  for(auto& format: jservice.GetArray())
+  {
+    rapidjson::Value::ConstMemberIterator jit = format.FindMember("CoverageSummary");
+
+    eows::ogc::wcs::core::coverage_summary_t coverage_summary;
+    coverage_summary.coverage_id = read_node_as_string(jit->value, "id");
+    coverage_summary.coverage_subtype = read_node_as_string(jit->value, "subtype");
+    content.summaries.push_back(coverage_summary);
+  }
+}

--- a/src/eows/ogc/wcs/core/utils.hpp
+++ b/src/eows/ogc/wcs/core/utils.hpp
@@ -1,0 +1,61 @@
+#ifndef __EOWS_OGC_WCS_CORE_UTILS_HPP__
+#define __EOWS_OGC_WCS_CORE_UTILS_HPP__
+
+// STL
+#include <string>
+
+// RapidJSON
+#include <rapidjson/document.h>
+
+namespace eows
+{
+  namespace ogc
+  {
+    namespace wcs
+    {
+      namespace core
+      {
+        // Forward declarations
+        struct capabilities_t;
+        struct service_identification_t;
+        struct service_provider_t;
+        struct service_metadata_t;
+        struct content_t;
+
+        /**
+         * @brief It tries to read rapidjson node value as string.
+         * @throws eows::parse_error When could not read or process as string like
+         * @return String value of node
+         */
+        const std::string read_node_as_string(const rapidjson::Value&, const std::string&);
+
+        /**
+         * @brief It reads WCS Capabilities from JSON document and fill values into capabilities object
+         */
+        void read(const rapidjson::Value&, capabilities_t&);
+
+        /**
+         * @brief It reads WCS Service Provider from JSON document and fill values into provider object
+         */
+        void read(const rapidjson::Value&, service_provider_t &);
+
+        /**
+         * @brief It reads WCS Service Identification from JSON document and fill values into object
+         */
+        void read(const rapidjson::Value&, service_identification_t&);
+
+        /**
+         * @brief It reads WCS Service Metadata from JSON document and fill values into object
+         */
+        void read(const rapidjson::Value&, service_metadata_t&);
+
+        /**
+         * @brief It reads WCS Contents from JSON document and fill values into object
+         */
+        void read(const rapidjson::Value&, content_t&);
+      }
+    }
+  }
+}
+
+#endif // __EOWS_OGC_WCS_CORE_UTILS_HPP__

--- a/src/eows/ogc/wcs/core/utils.hpp
+++ b/src/eows/ogc/wcs/core/utils.hpp
@@ -3,6 +3,7 @@
 
 // STL
 #include <string>
+#include <map>
 
 // RapidJSON
 #include <rapidjson/document.h>
@@ -53,6 +54,18 @@ namespace eows
          * @brief It reads WCS Contents from JSON document and fill values into object
          */
         void read(const rapidjson::Value&, content_t&);
+
+        /**
+         * @brief It transforms a string into lowercase
+         * @return String lowercase
+         */
+        std::string to_lower(const std::string&);
+
+        /**
+         * @brief It applies lower case on given map keys and return a new map with these values
+         * @return Copy map with keys in lowercase
+         */
+        std::map<std::string, std::string> lowerify(const std::map<std::string, std::string>&);
       }
     }
   }

--- a/src/eows/ogc/wcs/core/utils.hpp
+++ b/src/eows/ogc/wcs/core/utils.hpp
@@ -22,6 +22,7 @@ namespace eows
         struct service_provider_t;
         struct service_metadata_t;
         struct content_t;
+        struct operation_metadata_t;
 
         /**
          * @brief It tries to read rapidjson node value as string.
@@ -54,6 +55,11 @@ namespace eows
          * @brief It reads WCS Contents from JSON document and fill values into object
          */
         void read(const rapidjson::Value&, content_t&);
+
+        /**
+         * @brief It reads WCS Operations metadata from JSON document and fill values into object
+         */
+        void read(const rapidjson::Value &, operation_metadata_t&);
 
         /**
          * @brief It transforms a string into lowercase

--- a/src/eows/ogc/wcs/manager.cpp
+++ b/src/eows/ogc/wcs/manager.cpp
@@ -1,3 +1,30 @@
+/*
+  Copyright (C) 2017 National Institute For Space Research (INPE) - Brazil.
+
+  This file is part of Earth Observation Web Services (EOWS).
+
+  EOWS is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License version 3 as
+  published by the Free Software Foundation.
+
+  EOWS is distributed  "AS-IS" in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY OF ANY KIND; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with EOWS. See LICENSE. If not, write to
+  e-sensing team at <esensing-team@dpi.inpe.br>.
+ */
+
+/*!
+  \file eows/ogc/wcs/manager.cpp
+
+  \brief This class defines the implementation of WCS meta information access
+
+  \author Raphael Willian da Costa
+ */
+
 // EOWS
 #include "manager.hpp"
 #include "../../core/app_settings.hpp"

--- a/src/eows/ogc/wcs/manager.cpp
+++ b/src/eows/ogc/wcs/manager.cpp
@@ -1,12 +1,12 @@
+// EOWS
 #include "manager.hpp"
-#include "exception.hpp"
-#include "core/utils.hpp"
-#include "core/data_types.hpp"
 #include "../../core/app_settings.hpp"
 #include "../../core/utils.hpp"
 #include "../../core/defines.hpp"
 #include "../../core/logger.hpp"
-
+#include "exception.hpp"
+#include "core/utils.hpp"
+#include "core/data_types.hpp"
 
 // Boost
 #include <boost/filesystem.hpp>
@@ -20,6 +20,11 @@ struct eows::ogc::wcs::manager::impl
 eows::ogc::wcs::manager::manager()
   : pimpl_(new impl)
 {
+}
+
+eows::ogc::wcs::manager::~manager()
+{
+  delete pimpl_;
 }
 
 eows::ogc::wcs::manager& eows::ogc::wcs::manager::instance()

--- a/src/eows/ogc/wcs/manager.cpp
+++ b/src/eows/ogc/wcs/manager.cpp
@@ -1,0 +1,54 @@
+#include "manager.hpp"
+#include "exception.hpp"
+#include "core/utils.hpp"
+#include "core/data_types.hpp"
+#include "../../core/app_settings.hpp"
+#include "../../core/utils.hpp"
+#include "../../core/defines.hpp"
+#include "../../core/logger.hpp"
+
+
+// Boost
+#include <boost/filesystem.hpp>
+#include <boost/format.hpp>
+
+struct eows::ogc::wcs::manager::impl
+{
+  eows::ogc::wcs::core::capabilities_t capabilities;
+};
+
+eows::ogc::wcs::manager::manager()
+  : pimpl_(new impl)
+{
+}
+
+eows::ogc::wcs::manager& eows::ogc::wcs::manager::instance()
+{
+  static manager singleton;
+  return singleton;
+}
+
+const eows::ogc::wcs::core::capabilities_t& eows::ogc::wcs::manager::capabilities() const
+{
+  return pimpl_->capabilities;
+}
+
+void eows::ogc::wcs::manager::initialize()
+{
+  boost::filesystem::path cfg_file(eows::core::app_settings::instance().get_base_dir());
+
+  cfg_file /= EOWS_WCS_FILE;
+
+  EOWS_LOG_INFO("Reading file '" + cfg_file.string() + "'...");
+
+  rapidjson::Document doc = eows::core::open_json_file(cfg_file.string());
+
+  if(!doc.HasMember("WCSCapabilities"))
+    throw eows::parse_error("Please, check key 'WCSCapabilities' in file '" EOWS_WCS_FILE "'.");
+
+  const rapidjson::Value& jcapabilities = doc["WCSCapabilities"];
+
+  core::read(jcapabilities, pimpl_->capabilities);
+
+  EOWS_LOG_INFO("Finished reading file '" + cfg_file.string() + "'!");
+}

--- a/src/eows/ogc/wcs/manager.hpp
+++ b/src/eows/ogc/wcs/manager.hpp
@@ -1,6 +1,7 @@
 #ifndef __EOWS_OGC_WCS_MANAGER_HPP__
 #define __EOWS_OGC_WCS_MANAGER_HPP__
 
+// Boost dependency
 #include <boost/noncopyable.hpp>
 
 namespace eows
@@ -11,22 +12,32 @@ namespace eows
     {
       namespace core
       {
+        // Forward declarations
         struct capabilities_t;
       }
 
       class manager : private boost::noncopyable
       {
         public:
-          const core::capabilities_t& capabilities() const;
+          ~manager();
 
+          /**
+           * @brief It retrieves cached GetCapabilities meta information
+           * @return Capabilities instance with values
+           */
+          const core::capabilities_t& capabilities() const;
+          /**
+           * @brief It initializes Manager scope, loading WCS meta information into memory
+           */
           void initialize();
 
+          //! Singleton style
           static manager& instance();
 
         private:
-          // Singleton style
+          //! Singleton style
           manager();
-
+          //! Pimpl idiom
           struct impl;
           impl* pimpl_;
       };

--- a/src/eows/ogc/wcs/manager.hpp
+++ b/src/eows/ogc/wcs/manager.hpp
@@ -1,0 +1,37 @@
+#ifndef __EOWS_OGC_WCS_MANAGER_HPP__
+#define __EOWS_OGC_WCS_MANAGER_HPP__
+
+#include <boost/noncopyable.hpp>
+
+namespace eows
+{
+  namespace ogc
+  {
+    namespace wcs
+    {
+      namespace core
+      {
+        struct capabilities_t;
+      }
+
+      class manager : private boost::noncopyable
+      {
+        public:
+          const core::capabilities_t& capabilities() const;
+
+          void initialize();
+
+          static manager& instance();
+
+        private:
+          // Singleton style
+          manager();
+
+          struct impl;
+          impl* pimpl_;
+      };
+    }
+  }
+}
+
+#endif //__EOWS_OGC_WCS_MANAGER_HPP__

--- a/src/eows/ogc/wcs/manager.hpp
+++ b/src/eows/ogc/wcs/manager.hpp
@@ -1,3 +1,30 @@
+/*
+  Copyright (C) 2017 National Institute For Space Research (INPE) - Brazil.
+
+  This file is part of Earth Observation Web Services (EOWS).
+
+  EOWS is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License version 3 as
+  published by the Free Software Foundation.
+
+  EOWS is distributed  "AS-IS" in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY OF ANY KIND; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with EOWS. See LICENSE. If not, write to
+  e-sensing team at <esensing-team@dpi.inpe.br>.
+ */
+
+/*!
+  \file eows/ogc/wcs/manager.hpp
+
+  \brief This class defines a WCS meta information access
+
+  \author Raphael Willian da Costa
+ */
+
 #ifndef __EOWS_OGC_WCS_MANAGER_HPP__
 #define __EOWS_OGC_WCS_MANAGER_HPP__
 

--- a/src/eows/ogc/wcs/operations/data_types.cpp
+++ b/src/eows/ogc/wcs/operations/data_types.cpp
@@ -1,0 +1,6 @@
+#include "data_types.hpp"
+
+eows::ogc::wcs::operations::BaseRequest::BaseRequest()
+{
+
+}

--- a/src/eows/ogc/wcs/operations/data_types.cpp
+++ b/src/eows/ogc/wcs/operations/data_types.cpp
@@ -1,6 +1,0 @@
-#include "data_types.hpp"
-
-eows::ogc::wcs::operations::BaseRequest::BaseRequest()
-{
-
-}

--- a/src/eows/ogc/wcs/operations/data_types.hpp
+++ b/src/eows/ogc/wcs/operations/data_types.hpp
@@ -71,6 +71,8 @@ namespace eows
             }
           }
 
+          virtual ~base_request() {}
+
           std::string request;
           std::string version;
           std::string service;

--- a/src/eows/ogc/wcs/operations/data_types.hpp
+++ b/src/eows/ogc/wcs/operations/data_types.hpp
@@ -1,0 +1,49 @@
+#ifndef __EOF_OGC_WCS_OPERATIONS_CORE_DATA_TYPES__
+#define __EOF_OGC_WCS_OPERATIONS_CORE_DATA_TYPES__
+
+// STL
+#include <string>
+#include <vector>
+
+namespace eows
+{
+  namespace ogc
+  {
+    namespace wcs
+    {
+      namespace operations
+      {
+        /**
+         * @brief It represents a base request structure for WCS access
+         */
+        struct BaseRequest
+        {
+          std::string request;
+          std::string version;
+          std::string service;
+        };
+        /**
+         * @brief Represents a GetCapabilities request structure
+         */
+        struct GetCapabilitiesRequest : public BaseRequest { };
+        /**
+         * @brief Represents DescriveCoverage Request structure
+         */
+        struct DescribeCoverageRequest : public BaseRequest
+        {
+          std::string coverageId;
+        };
+        /**
+         * @brief Represents GetCoverage request structure
+         */
+        struct GetCoverageRequest : public BaseRequest
+        {
+          std::string coverageId;
+          // TODO: implement
+        };
+      }
+    }
+  }
+}
+
+#endif // __EOF_OGC_WCS_OPERATIONS_CORE_DATA_TYPES__

--- a/src/eows/ogc/wcs/operations/data_types.hpp
+++ b/src/eows/ogc/wcs/operations/data_types.hpp
@@ -1,11 +1,35 @@
+/*
+  Copyright (C) 2017 National Institute For Space Research (INPE) - Brazil.
+
+  This file is part of Earth Observation Web Services (EOWS).
+
+  EOWS is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License version 3 as
+  published by the Free Software Foundation.
+
+  EOWS is distributed  "AS-IS" in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY OF ANY KIND; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with EOWS. See LICENSE. If not, write to
+  e-sensing team at <esensing-team@dpi.inpe.br>.
+ */
+
+/*!
+  \file eows/ogc/wcs/operations/data_types.hpp
+
+  \brief Represents a OGC WCS operations data types like WCS Request Parameters
+
+  \author Raphael Willian da Costa
+ */
+
 #ifndef __EOF_OGC_WCS_OPERATIONS_CORE_DATA_TYPES__
 #define __EOF_OGC_WCS_OPERATIONS_CORE_DATA_TYPES__
 
-// EOWS
-#include "../../../core/data_types.hpp"
 // STL
 #include <string>
-#include <vector>
 
 namespace eows
 {
@@ -20,7 +44,6 @@ namespace eows
          */
         struct BaseRequest
         {
-          BaseRequest();
           std::string request;
           std::string version;
           std::string service;

--- a/src/eows/ogc/wcs/operations/data_types.hpp
+++ b/src/eows/ogc/wcs/operations/data_types.hpp
@@ -28,6 +28,8 @@
 #ifndef __EOF_OGC_WCS_OPERATIONS_CORE_DATA_TYPES__
 #define __EOF_OGC_WCS_OPERATIONS_CORE_DATA_TYPES__
 
+#include "../../../core/data_types.hpp"
+#include "../exception.hpp"
 // STL
 #include <string>
 
@@ -41,9 +43,34 @@ namespace eows
       {
         /**
          * @brief It represents a base request structure for WCS access
+         * @throws
          */
-        struct BaseRequest
+        struct base_request
         {
+          base_request(const eows::core::query_string_t& query)
+            : request(), version(), service()
+          {
+            eows::core::query_string_t::const_iterator it = query.find("request");
+
+            if (it == query.end()) {
+              throw eows::ogc::missing_parameter_error("Missing parameter 'request'", "request");
+            }
+            request = it->second;
+
+            it = query.find("service");
+
+            if (it == query.end()) {
+              throw eows::ogc::missing_parameter_error("Missing parameter 'service'", "service");
+            }
+            service = it->second;
+
+            it = query.find("version");
+
+            if (it != query.end()) {
+              version = it->second;
+            }
+          }
+
           std::string request;
           std::string version;
           std::string service;
@@ -51,18 +78,24 @@ namespace eows
         /**
          * @brief Represents a GetCapabilities request structure
          */
-        struct GetCapabilitiesRequest : public BaseRequest { };
+        struct get_capabilities_request : public base_request
+        {
+          get_capabilities_request(const eows::core::query_string_t& query)
+            : base_request(query)
+          {
+          }
+        };
         /**
          * @brief Represents DescriveCoverage Request structure
          */
-        struct DescribeCoverageRequest : public BaseRequest
+        struct describe_coverage_request : public base_request
         {
           std::string coverageId;
         };
         /**
          * @brief Represents GetCoverage request structure
          */
-        struct GetCoverageRequest : public BaseRequest
+        struct get_coverage_request : public base_request
         {
           std::string coverageId;
           // TODO: implement

--- a/src/eows/ogc/wcs/operations/data_types.hpp
+++ b/src/eows/ogc/wcs/operations/data_types.hpp
@@ -1,6 +1,8 @@
 #ifndef __EOF_OGC_WCS_OPERATIONS_CORE_DATA_TYPES__
 #define __EOF_OGC_WCS_OPERATIONS_CORE_DATA_TYPES__
 
+// EOWS
+#include "../../../core/data_types.hpp"
 // STL
 #include <string>
 #include <vector>
@@ -18,6 +20,7 @@ namespace eows
          */
         struct BaseRequest
         {
+          BaseRequest();
           std::string request;
           std::string version;
           std::string service;

--- a/src/eows/ogc/wcs/operations/error_handler.cpp
+++ b/src/eows/ogc/wcs/operations/error_handler.cpp
@@ -29,6 +29,8 @@
 // EOWS
 #include "error_handler.hpp"
 #include "../exception.hpp"
+#include "../core/data_types.hpp"
+#include "../manager.hpp"
 // RapidXML
 #include <rapidxml/rapidxml.hpp>
 #include <rapidxml/rapidxml_print.hpp>
@@ -41,9 +43,12 @@ const std::string eows::ogc::wcs::operations::handle_error(const ogc_error& e)
   decl->append_attribute(xml_doc.allocate_attribute("version", "1.0"));
   decl->append_attribute(xml_doc.allocate_attribute("encoding", "UTF-8"));
   xml_doc.append_node(decl);
+
+  const eows::ogc::wcs::core::capabilities_t& capabilities = eows::ogc::wcs::manager::instance().capabilities();
+  const std::string& wcs_version = capabilities.service.service_type_version;
   // Preparing WCS Root element
   rapidxml::xml_node<>* root = xml_doc.allocate_node(rapidxml::node_element, "ows:ExceptionReport");
-  root->append_attribute(xml_doc.allocate_attribute("version", "2.0.0"));
+  root->append_attribute(xml_doc.allocate_attribute("version", wcs_version.c_str()));
   root->append_attribute(xml_doc.allocate_attribute("xmlns","http://www.opengis.net/ows/2.0"));
   root->append_attribute(xml_doc.allocate_attribute("xmlns:ows","http://www.opengis.net/ows/2.0"));
   root->append_attribute(xml_doc.allocate_attribute("xmlns:xsi","http://www.w3.org/2001/XMLSchema-instance"));
@@ -53,6 +58,7 @@ const std::string eows::ogc::wcs::operations::handle_error(const ogc_error& e)
   rapidxml::xml_node<>* exception = xml_doc.allocate_node(rapidxml::node_element, "ows:Exception");
   rapidxml::xml_attribute<>* attr = xml_doc.allocate_attribute("exceptionCode", e.error_code.c_str());
   exception->append_attribute(attr);
+  // TODO: Retrieve what the user specified
   attr = xml_doc.allocate_attribute("locator", "");
   exception->append_attribute(attr);
   // Preparing WCS exception text

--- a/src/eows/ogc/wcs/operations/error_handler.cpp
+++ b/src/eows/ogc/wcs/operations/error_handler.cpp
@@ -1,0 +1,66 @@
+/*
+  Copyright (C) 2017 National Institute For Space Research (INPE) - Brazil.
+
+  This file is part of Earth Observation Web Services (EOWS).
+
+  EOWS is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License version 3 as
+  published by the Free Software Foundation.
+
+  EOWS is distributed  "AS-IS" in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY OF ANY KIND; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with EOWS. See LICENSE. If not, write to
+  e-sensing team at <esensing-team@dpi.inpe.br>.
+ */
+
+/*!
+  \file eows/ogc/wcs/operations/error_handler.cpp
+
+  \brief Represents implementation of WCS exception handler
+
+  \author Raphael Willian da Costa
+ */
+
+
+// EOWS
+#include "error_handler.hpp"
+#include "../exception.hpp"
+// RapidXML
+#include <rapidxml/rapidxml.hpp>
+#include <rapidxml/rapidxml_print.hpp>
+
+const std::string eows::ogc::wcs::operations::handle_error(const ogc_error& e)
+{
+  rapidxml::xml_document<> xml_doc;
+  // Preparing Meta document
+  rapidxml::xml_node<>* decl = xml_doc.allocate_node(rapidxml::node_declaration);
+  decl->append_attribute(xml_doc.allocate_attribute("version", "1.0"));
+  decl->append_attribute(xml_doc.allocate_attribute("encoding", "UTF-8"));
+  xml_doc.append_node(decl);
+  // Preparing WCS Root element
+  rapidxml::xml_node<>* root = xml_doc.allocate_node(rapidxml::node_element, "ows:ExceptionReport");
+  root->append_attribute(xml_doc.allocate_attribute("version", "2.0.0"));
+  root->append_attribute(xml_doc.allocate_attribute("xmlns","http://www.opengis.net/ows/2.0"));
+  root->append_attribute(xml_doc.allocate_attribute("xmlns:ows","http://www.opengis.net/ows/2.0"));
+  root->append_attribute(xml_doc.allocate_attribute("xmlns:xsi","http://www.w3.org/2001/XMLSchema-instance"));
+  root->append_attribute(xml_doc.allocate_attribute("xsi:schemaLocation","http://www.opengis.net/ows/2.0 http://schemas.opengis.net/ows/2.0/owsExceptionReport.xsd"));
+  xml_doc.append_node(root);
+
+  rapidxml::xml_node<>* exception = xml_doc.allocate_node(rapidxml::node_element, "ows:Exception");
+  rapidxml::xml_attribute<>* attr = xml_doc.allocate_attribute("exceptionCode", e.error_code.c_str());
+  exception->append_attribute(attr);
+  attr = xml_doc.allocate_attribute("locator", "");
+  exception->append_attribute(attr);
+  // Preparing WCS exception text
+  rapidxml::xml_node<>* exception_text = xml_doc.allocate_node(rapidxml::node_element, "ows:ExceptionText", e.what());
+  exception->append_node(exception_text);
+  root->append_node(exception);
+
+  std::string buff;
+  rapidxml::print(std::back_inserter(buff), xml_doc, 0);
+  return buff;
+}

--- a/src/eows/ogc/wcs/operations/error_handler.hpp
+++ b/src/eows/ogc/wcs/operations/error_handler.hpp
@@ -1,0 +1,56 @@
+/*
+  Copyright (C) 2017 National Institute For Space Research (INPE) - Brazil.
+
+  This file is part of Earth Observation Web Services (EOWS).
+
+  EOWS is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License version 3 as
+  published by the Free Software Foundation.
+
+  EOWS is distributed  "AS-IS" in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY OF ANY KIND; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with EOWS. See LICENSE. If not, write to
+  e-sensing team at <esensing-team@dpi.inpe.br>.
+ */
+
+/*!
+  \file eows/ogc/wcs/operations/error_handler.cpp
+
+  \brief This class defines WCS 2.0 error handler
+
+  \author Raphael Willian da Costa
+ */
+
+#ifndef __EOWS_OGC_WCS_OPERATIONS_ERROR_HANDLES_HPP__
+#define __EOWS_OGC_WCS_OPERATIONS_ERROR_HANDLES_HPP__
+
+// EOWS
+#include "../core/operation.hpp"
+
+#include "../../exception.hpp"
+
+namespace eows
+{
+  namespace ogc
+  {
+    namespace wcs
+    {
+      namespace operations
+      {
+        /**
+         * @brief It prepares WCS 2.0 XML error using eows ogc exception.
+         * @todo Should it handle std::exception?
+         *
+         * @return String representation (XML) of WCS 2.0 error document
+         */
+        const std::string handle_error(const eows::ogc::ogc_error&);
+      }
+    }
+  }
+}
+
+#endif // __EOWS_OGC_WCS_OPERATIONS_ERROR_HANDLES_HPP__

--- a/src/eows/ogc/wcs/operations/factory.cpp
+++ b/src/eows/ogc/wcs/operations/factory.cpp
@@ -1,7 +1,34 @@
+/*
+  Copyright (C) 2017 National Institute For Space Research (INPE) - Brazil.
+
+  This file is part of Earth Observation Web Services (EOWS).
+
+  EOWS is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License version 3 as
+  published by the Free Software Foundation.
+
+  EOWS is distributed  "AS-IS" in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY OF ANY KIND; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with EOWS. See LICENSE. If not, write to
+  e-sensing team at <esensing-team@dpi.inpe.br>.
+ */
+
+/*!
+  \file eows/ogc/wcs/operations/factory.cpp
+
+  \brief Defines implementation of WCS factory operation builder
+
+  \author Raphael Willian da Costa
+ */
+
 // EOWS WCS
 #include "factory.hpp"
 #include "../core/operation.hpp"
-
+#include "../core/utils.hpp"
 #include "../exception.hpp"
 // WCS Operation Data Types
 #include "data_types.hpp"
@@ -15,33 +42,26 @@ std::unique_ptr<eows::ogc::wcs::core::operation> eows::ogc::wcs::operations::bui
     throw eows::ogc::missing_parameter_error("Missing parameter 'request'");
   }
 
-  eows::core::query_string_t::const_iterator it = query.find("version");
-
-  if (it == query.end()) {
-    throw eows::ogc::missing_parameter_error("Missing parameter 'version'");
-  }
-
-  it = query.find("service");
+  eows::core::query_string_t::const_iterator it = query.find("service");
 
   if (it == query.end()) {
     throw eows::ogc::missing_parameter_error("Missing parameter 'service'");
   }
 
   std::unique_ptr<eows::ogc::wcs::core::operation> op;
-  // Checking which operation should build
-  // TODO: Put everything to lowercase-style
-  if (request_it->second == "GetCapabilities")
+
+  if (eows::ogc::wcs::core::to_lower(request_it->second) == "getcapabilities")
   {
     GetCapabilitiesRequest capabilities_request;
     op.reset(new get_capabilities());
     return std::move(op);
   }
-  else if (request_it->second == "DescribeCoverage")
+  else if (eows::ogc::wcs::core::to_lower(request_it->second) == "describecoverage")
   {
-    throw eows::ogc::not_implemented_error("Missing parameter 'VERSION'");
+    throw eows::ogc::not_implemented_error("Describe Coverage is not implemented yet");
   }
   else //if (request_it->second == "GetCoverage")
   {
-    throw eows::ogc::not_implemented_error("Missing parameter 'VERSION'");
+    throw eows::ogc::not_implemented_error("Not implemented yet");
   }
 }

--- a/src/eows/ogc/wcs/operations/factory.cpp
+++ b/src/eows/ogc/wcs/operations/factory.cpp
@@ -7,7 +7,7 @@
 #include "data_types.hpp"
 #include "get_capabilities.hpp"
 
-const eows::ogc::wcs::core::operation* eows::ogc::wcs::operations::build_operation(const eows::core::query_string_t& query)
+std::unique_ptr<eows::ogc::wcs::core::operation> eows::ogc::wcs::operations::build_operation(const eows::core::query_string_t& query)
 {
   eows::core::query_string_t::const_iterator request_it = query.find("request");
 
@@ -27,12 +27,14 @@ const eows::ogc::wcs::core::operation* eows::ogc::wcs::operations::build_operati
     throw eows::ogc::missing_parameter_error("Missing parameter 'service'");
   }
 
+  std::unique_ptr<eows::ogc::wcs::core::operation> op;
   // Checking which operation should build
   // TODO: Put everything to lowercase-style
   if (request_it->second == "GetCapabilities")
   {
     GetCapabilitiesRequest capabilities_request;
-    return new get_capabilities();
+    op.reset(new get_capabilities());
+    return std::move(op);
   }
   else if (request_it->second == "DescribeCoverage")
   {

--- a/src/eows/ogc/wcs/operations/factory.cpp
+++ b/src/eows/ogc/wcs/operations/factory.cpp
@@ -1,0 +1,45 @@
+// EOWS WCS
+#include "factory.hpp"
+#include "../core/operation.hpp"
+
+#include "../exception.hpp"
+// WCS Operation Data Types
+#include "data_types.hpp"
+#include "get_capabilities.hpp"
+
+const eows::ogc::wcs::core::operation* eows::ogc::wcs::operations::build_operation(const eows::core::query_string_t& query)
+{
+  eows::core::query_string_t::const_iterator request_it = query.find("request");
+
+  if (request_it == query.end()) {
+    throw eows::ogc::missing_parameter_error("Missing parameter 'request'");
+  }
+
+  eows::core::query_string_t::const_iterator it = query.find("version");
+
+  if (it == query.end()) {
+    throw eows::ogc::missing_parameter_error("Missing parameter 'version'");
+  }
+
+  it = query.find("service");
+
+  if (it == query.end()) {
+    throw eows::ogc::missing_parameter_error("Missing parameter 'service'");
+  }
+
+  // Checking which operation should build
+  // TODO: Put everything to lowercase-style
+  if (request_it->second == "GetCapabilities")
+  {
+    GetCapabilitiesRequest capabilities_request;
+    return new get_capabilities();
+  }
+  else if (request_it->second == "DescribeCoverage")
+  {
+    throw eows::ogc::not_implemented_error("Missing parameter 'VERSION'");
+  }
+  else //if (request_it->second == "GetCoverage")
+  {
+    throw eows::ogc::not_implemented_error("Missing parameter 'VERSION'");
+  }
+}

--- a/src/eows/ogc/wcs/operations/factory.cpp
+++ b/src/eows/ogc/wcs/operations/factory.cpp
@@ -25,13 +25,14 @@
   \author Raphael Willian da Costa
  */
 
-// EOWS WCS
+// EOWS
 #include "factory.hpp"
 #include "../core/operation.hpp"
 #include "../core/utils.hpp"
 #include "../exception.hpp"
 // WCS Operation Data Types
 #include "data_types.hpp"
+// WCS Operation to build
 #include "get_capabilities.hpp"
 
 std::unique_ptr<eows::ogc::wcs::core::operation> eows::ogc::wcs::operations::build_operation(const eows::core::query_string_t& query)
@@ -39,29 +40,24 @@ std::unique_ptr<eows::ogc::wcs::core::operation> eows::ogc::wcs::operations::bui
   eows::core::query_string_t::const_iterator request_it = query.find("request");
 
   if (request_it == query.end()) {
-    throw eows::ogc::missing_parameter_error("Missing parameter 'request'");
-  }
-
-  eows::core::query_string_t::const_iterator it = query.find("service");
-
-  if (it == query.end()) {
-    throw eows::ogc::missing_parameter_error("Missing parameter 'service'");
+    throw eows::ogc::missing_parameter_error("Missing parameter 'request'", "request");
   }
 
   std::unique_ptr<eows::ogc::wcs::core::operation> op;
 
   if (eows::ogc::wcs::core::to_lower(request_it->second) == "getcapabilities")
   {
-    GetCapabilitiesRequest capabilities_request;
-    op.reset(new get_capabilities());
+    get_capabilities_request capabilities_request(query);
+    op.reset(new get_capabilities(capabilities_request));
     return std::move(op);
   }
   else if (eows::ogc::wcs::core::to_lower(request_it->second) == "describecoverage")
   {
-    throw eows::ogc::not_implemented_error("Describe Coverage is not implemented yet");
+    throw eows::ogc::not_implemented_error("Describe Coverage is not implemented yet", "request");
   }
-  else //if (request_it->second == "GetCoverage")
+  else if (request_it->second == "GetCoverage")
   {
-    throw eows::ogc::not_implemented_error("Not implemented yet");
+    throw eows::ogc::not_implemented_error("Not implemented yet", "request");
   }
+  throw eows::ogc::ogc_error("Invalid WCS operation", "OperationNotSupported");
 }

--- a/src/eows/ogc/wcs/operations/factory.hpp
+++ b/src/eows/ogc/wcs/operations/factory.hpp
@@ -1,0 +1,27 @@
+#ifndef __EOWS_OGC_WCS_OPERATIONS_HPP__
+#define __EOWS_OGC_WCS_OPERATIONS_HPP__
+
+#include "../../../core/data_types.hpp"
+#include "../core/data_types.hpp"
+
+namespace eows
+{
+  namespace ogc
+  {
+    namespace wcs
+    {
+      namespace core
+      {
+        class operation;
+      }
+
+      namespace operations
+      {
+        // TODO: Remove pointer return. it is un-safe
+        const eows::ogc::wcs::core::operation* build_operation(const eows::core::query_string_t&);
+      }
+    }
+  }
+}
+
+#endif // __EOWS_OGC_WCS_OPERATIONS_HPP__

--- a/src/eows/ogc/wcs/operations/factory.hpp
+++ b/src/eows/ogc/wcs/operations/factory.hpp
@@ -1,3 +1,30 @@
+/*
+  Copyright (C) 2017 National Institute For Space Research (INPE) - Brazil.
+
+  This file is part of Earth Observation Web Services (EOWS).
+
+  EOWS is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License version 3 as
+  published by the Free Software Foundation.
+
+  EOWS is distributed  "AS-IS" in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY OF ANY KIND; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with EOWS. See LICENSE. If not, write to
+  e-sensing team at <esensing-team@dpi.inpe.br>.
+ */
+
+/*!
+  \file eows/ogc/wcs/operations/factory.hpp
+
+  \brief Represents a factory WCS operation builder
+
+  \author Raphael Willian da Costa
+ */
+
 #ifndef __EOWS_OGC_WCS_OPERATIONS_HPP__
 #define __EOWS_OGC_WCS_OPERATIONS_HPP__
 

--- a/src/eows/ogc/wcs/operations/factory.hpp
+++ b/src/eows/ogc/wcs/operations/factory.hpp
@@ -1,8 +1,10 @@
 #ifndef __EOWS_OGC_WCS_OPERATIONS_HPP__
 #define __EOWS_OGC_WCS_OPERATIONS_HPP__
 
+// EOWS
 #include "../../../core/data_types.hpp"
-#include "../core/data_types.hpp"
+// STL
+#include <memory>
 
 namespace eows
 {
@@ -12,13 +14,18 @@ namespace eows
     {
       namespace core
       {
+        //! Forward declarations
         class operation;
       }
 
       namespace operations
       {
-        // TODO: Remove pointer return. it is un-safe
-        const eows::ogc::wcs::core::operation* build_operation(const eows::core::query_string_t&);
+        /**
+         * @brief It builds a OGC WCS operation based on query string
+         * @throws missing_parameter_error When request does not match required arguments
+         * @return Unique Ptr to the built operation
+         */
+        std::unique_ptr<eows::ogc::wcs::core::operation> build_operation(const eows::core::query_string_t&);
       }
     }
   }

--- a/src/eows/ogc/wcs/operations/get_capabilities.cpp
+++ b/src/eows/ogc/wcs/operations/get_capabilities.cpp
@@ -1,3 +1,31 @@
+/*
+  Copyright (C) 2017 National Institute For Space Research (INPE) - Brazil.
+
+  This file is part of Earth Observation Web Services (EOWS).
+
+  EOWS is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License version 3 as
+  published by the Free Software Foundation.
+
+  EOWS is distributed  "AS-IS" in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY OF ANY KIND; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with EOWS. See LICENSE. If not, write to
+  e-sensing team at <esensing-team@dpi.inpe.br>.
+ */
+
+/*!
+  \file eows/ogc/wcs/operations/get_capabilities.cpp
+
+  \brief Defines implementation of WCS GetCapabilities operation
+
+  \author Raphael Willian da Costa
+ */
+
+// EOWS
 #include "get_capabilities.hpp"
 #include "../core/data_types.hpp"
 #include "../manager.hpp"

--- a/src/eows/ogc/wcs/operations/get_capabilities.cpp
+++ b/src/eows/ogc/wcs/operations/get_capabilities.cpp
@@ -17,6 +17,11 @@ eows::ogc::wcs::operations::get_capabilities::~get_capabilities()
 
 }
 
+void eows::ogc::wcs::operations::get_capabilities::execute()
+{
+
+}
+
 const char*eows::ogc::wcs::operations::get_capabilities::content_type() const
 {
   return "application/gml+xml";
@@ -115,7 +120,34 @@ const std::string eows::ogc::wcs::operations::get_capabilities::to_string() cons
   // ================
   // Service Metadata
   // ================
+  child = xml_doc.allocate_node(rapidxml::node_element, "wcs:ServiceMetadata");
+  for(auto& format: capabilities.service_metadata.formats_supported)
+  {
+    sub_child = xml_doc.allocate_node(rapidxml::node_element, "wcs:formatSupported");
+    sub_child->value(format.c_str());
+    child->append_node(sub_child);
+  }
+  wcs_document->append_node(child);
 
+  // ========
+  // Contents
+  // ========
+  child = xml_doc.allocate_node(rapidxml::node_element, "wcs:Contents");
+  for(const eows::ogc::wcs::core::coverage_summary_t& summary: capabilities.content.summaries)
+  {
+    sub_child = xml_doc.allocate_node(rapidxml::node_element, "wcs:CoverageSummary");
+    {
+      rapidxml::xml_node<>* coverage_node = xml_doc.allocate_node(rapidxml::node_element, "wcs:CoverageId");
+      coverage_node->value(summary.coverage_id.c_str());
+      sub_child->append_node(coverage_node);
+
+      coverage_node = xml_doc.allocate_node(rapidxml::node_element, "wcs:CoverageSubtype");
+      coverage_node->value(summary.coverage_subtype.c_str());
+      sub_child->append_node(coverage_node);
+    }
+    child->append_node(sub_child);
+  }
+  wcs_document->append_node(child);
 
   std::string buff;
   rapidxml::print(std::back_inserter(buff), xml_doc, 0);

--- a/src/eows/ogc/wcs/operations/get_capabilities.cpp
+++ b/src/eows/ogc/wcs/operations/get_capabilities.cpp
@@ -58,7 +58,7 @@ eows::ogc::wcs::operations::get_capabilities::get_capabilities(const get_capabil
 
 eows::ogc::wcs::operations::get_capabilities::~get_capabilities()
 {
-
+  delete pimpl_;
 }
 
 void eows::ogc::wcs::operations::get_capabilities::execute()

--- a/src/eows/ogc/wcs/operations/get_capabilities.cpp
+++ b/src/eows/ogc/wcs/operations/get_capabilities.cpp
@@ -1,0 +1,124 @@
+#include "get_capabilities.hpp"
+#include "../core/data_types.hpp"
+#include "../manager.hpp"
+
+// RapidXML
+#include <rapidxml/rapidxml.hpp>
+#include <rapidxml/rapidxml_print.hpp>
+
+eows::ogc::wcs::operations::get_capabilities::get_capabilities()
+  : eows::ogc::wcs::core::operation()
+{
+
+}
+
+eows::ogc::wcs::operations::get_capabilities::~get_capabilities()
+{
+
+}
+
+const char*eows::ogc::wcs::operations::get_capabilities::content_type() const
+{
+  return "application/gml+xml";
+}
+
+const std::string eows::ogc::wcs::operations::get_capabilities::to_string() const
+{
+  const eows::ogc::wcs::core::capabilities_t capabilities = manager::instance().capabilities();
+
+  rapidxml::xml_document<> xml_doc;
+
+  // Preparing Meta document
+  rapidxml::xml_node<>* decl = xml_doc.allocate_node(rapidxml::node_declaration);
+  decl->append_attribute(xml_doc.allocate_attribute("version", "1.0"));
+  decl->append_attribute(xml_doc.allocate_attribute("encoding", "UTF-8"));
+  xml_doc.append_node(decl);
+  // Preparing WCS Root Element
+  rapidxml::xml_node<>* wcs_document = xml_doc.allocate_node(rapidxml::node_element, "wcs:WCSCapabilities");
+  wcs_document->append_attribute(xml_doc.allocate_attribute("version", capabilities.service.service_type_version.c_str()));
+  wcs_document->append_attribute(xml_doc.allocate_attribute("xmlns","http://www.opengis.net/ows/2.0"));
+  wcs_document->append_attribute(xml_doc.allocate_attribute("xmlns:ows","http://www.opengis.net/ows/2.0"));
+  wcs_document->append_attribute(xml_doc.allocate_attribute("xmlns:wcs","http://www.opengis.net/wcs/2.0"));
+  wcs_document->append_attribute(xml_doc.allocate_attribute("xmlns:gml","http://www.opengis.net/gml/3.2"));
+  wcs_document->append_attribute(xml_doc.allocate_attribute("xmlns:xsi","http://www.w3.org/2001/XMLSchema-instance"));
+  wcs_document->append_attribute(xml_doc.allocate_attribute("xsi:schemaLocation","http://www.opengis.net/wcs/2.0 http://schemas.opengis.net/wcs/2.0/wcsAll.xsd"));
+  xml_doc.append_node(wcs_document);
+
+  // OWS Identification
+  rapidxml::xml_node<>* ows_identification = xml_doc.allocate_node(rapidxml::node_element, "ows:ServiceIdentification");
+  rapidxml::xml_node<>* child = xml_doc.allocate_node(rapidxml::node_element, "ows:Title");
+
+  child->value(capabilities.service.title.c_str());
+  ows_identification->append_node(child);
+
+  child = xml_doc.allocate_node(rapidxml::node_element, "ows:Abstract");
+  child->value(capabilities.service.abstract.c_str());
+  ows_identification->append_node(child);
+
+  child = xml_doc.allocate_node(rapidxml::node_element, "ows:ServiceType");
+  child->value(capabilities.service.service_type.c_str());
+  ows_identification->append_node(child);
+
+  child = xml_doc.allocate_node(rapidxml::node_element, "ows:ServiceTypeVersion");
+  child->value(capabilities.service.service_type_version.c_str());
+  ows_identification->append_node(child);
+
+  for(auto profile: capabilities.service.profiles)
+  {
+    child = xml_doc.allocate_node(rapidxml::node_element, "ows:Profile");
+    child->value(profile.c_str());
+    ows_identification->append_node(child);
+  }
+
+  wcs_document->append_node(ows_identification);
+  // ==============
+  // OWS Provider
+  // ==============
+  rapidxml::xml_node<>* ows_provider = xml_doc.allocate_node(rapidxml::node_element, "ows:ServiceProvider");
+  child = xml_doc.allocate_node(rapidxml::node_element, "ows:ProviderName");
+  child->value(capabilities.service_provider.provider_name.c_str());
+  ows_provider->append_node(child);
+
+  child = xml_doc.allocate_node(rapidxml::node_element, "ows:ProviderSite");
+  child->value(capabilities.service_provider.provider_site.c_str());
+  ows_provider->append_node(child);
+
+  child = xml_doc.allocate_node(rapidxml::node_element, "ows:ServiceContact");
+  const eows::ogc::wcs::core::service_contact_t& contact = capabilities.service_provider.service_contact;
+  // Processing Provider -> Contact -> Nodes[]
+  rapidxml::xml_node<>* sub_child = xml_doc.allocate_node(rapidxml::node_element, "ows:IndividualName");
+  sub_child->value(contact.individual_name.c_str());
+  child->append_node(sub_child);
+
+  sub_child = xml_doc.allocate_node(rapidxml::node_element, "ows:PositionName");
+  sub_child->value(contact.position_name.c_str());
+  child->append_node(sub_child);
+  ows_provider->append_node(child);
+  wcs_document->append_node(ows_provider);
+
+  // ===================
+  // Operations Metadata
+  // ===================
+  // Attribute Iterator
+  rapidxml::xml_attribute<>* attr_it = xml_doc.allocate_attribute("name", "GetCapabilities");
+  child = xml_doc.allocate_node(rapidxml::node_element, "ows:OperationsMetadata");
+  // GetCapabilities Operation
+  sub_child = xml_doc.allocate_node(rapidxml::node_element, "ows:Operation");
+  sub_child->append_attribute(attr_it);
+  rapidxml::xml_node<>* dcp_node = xml_doc.allocate_node(rapidxml::node_element, "ows:DCP");
+  rapidxml::xml_node<>* http_node = xml_doc.allocate_node(rapidxml::node_element, "ows:HTTP");
+  attr_it = xml_doc.allocate_attribute("xlink:href", "http://localhost:7654/wcs");// TODO: apply it dynammically
+  http_node->append_attribute(attr_it);
+  dcp_node->append_node(http_node);
+  sub_child->append_node(dcp_node);
+
+  // ================
+  // Service Metadata
+  // ================
+
+
+  std::string buff;
+  rapidxml::print(std::back_inserter(buff), xml_doc, 0);
+
+  return buff;
+}

--- a/src/eows/ogc/wcs/operations/get_capabilities.cpp
+++ b/src/eows/ogc/wcs/operations/get_capabilities.cpp
@@ -32,7 +32,6 @@
 #include "../manager.hpp"
 #include "../core/utils.hpp"
 
-#include <iostream>
 // RapidXML
 #include <rapidxml/rapidxml.hpp>
 #include <rapidxml/rapidxml_print.hpp>
@@ -206,7 +205,6 @@ void eows::ogc::wcs::operations::get_capabilities::execute()
   wcs_document->append_node(child);
 
   rapidxml::print(std::back_inserter(pimpl_->xml_representation), xml_doc, 0);
-  std::cout << pimpl_->xml_representation << std::endl;
 }
 
 const char*eows::ogc::wcs::operations::get_capabilities::content_type() const

--- a/src/eows/ogc/wcs/operations/get_capabilities.hpp
+++ b/src/eows/ogc/wcs/operations/get_capabilities.hpp
@@ -1,0 +1,30 @@
+#ifndef __EOWS_OGC_WCS_OPERATIONS_GET_CAPABILITIES_HPP__
+#define __EOWS_OGC_WCS_OPERATIONS_GET_CAPABILITIES_HPP__
+
+#include "../core/operation.hpp"
+
+namespace eows
+{
+  namespace ogc
+  {
+    namespace wcs
+    {
+      namespace operations
+      {
+        class get_capabilities : public eows::ogc::wcs::core::operation
+        {
+          public:
+            get_capabilities();
+            ~get_capabilities();
+
+            const char* content_type() const;
+
+            const std::string to_string() const override;
+          private:
+        };
+      }
+    }
+  }
+}
+
+#endif // __EOWS_OGC_WCS_OPERATIONS_GET_CAPABILITIES_HPP__

--- a/src/eows/ogc/wcs/operations/get_capabilities.hpp
+++ b/src/eows/ogc/wcs/operations/get_capabilities.hpp
@@ -17,6 +17,12 @@ namespace eows
             get_capabilities();
             ~get_capabilities();
 
+            void execute();
+
+            /**
+             * @brief For WCS GetCapabilities operations, it is fixed to "application/gml+xml"
+             * @return
+             */
             const char* content_type() const;
 
             const std::string to_string() const override;

--- a/src/eows/ogc/wcs/operations/get_capabilities.hpp
+++ b/src/eows/ogc/wcs/operations/get_capabilities.hpp
@@ -1,6 +1,34 @@
+/*
+  Copyright (C) 2017 National Institute For Space Research (INPE) - Brazil.
+
+  This file is part of Earth Observation Web Services (EOWS).
+
+  EOWS is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License version 3 as
+  published by the Free Software Foundation.
+
+  EOWS is distributed  "AS-IS" in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY OF ANY KIND; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with EOWS. See LICENSE. If not, write to
+  e-sensing team at <esensing-team@dpi.inpe.br>.
+ */
+
+/*!
+  \file eows/ogc/wcs/operations/get_capabilities.hpp
+
+  \brief Represents WCS GetCapabilities operation that retrieves XML representation
+
+  \author Raphael Willian da Costa
+ */
+
 #ifndef __EOWS_OGC_WCS_OPERATIONS_GET_CAPABILITIES_HPP__
 #define __EOWS_OGC_WCS_OPERATIONS_GET_CAPABILITIES_HPP__
 
+// EOWS
 #include "../core/operation.hpp"
 
 namespace eows
@@ -11,6 +39,10 @@ namespace eows
     {
       namespace operations
       {
+        /**
+         * @brief Represents WCS GetCapabilities implementation
+         * It converts cached capability json document as gml+xml style
+         */
         class get_capabilities : public eows::ogc::wcs::core::operation
         {
           public:

--- a/src/eows/ogc/wcs/operations/get_capabilities.hpp
+++ b/src/eows/ogc/wcs/operations/get_capabilities.hpp
@@ -39,6 +39,8 @@ namespace eows
     {
       namespace operations
       {
+        struct get_capabilities_request;
+
         /**
          * @brief Represents WCS GetCapabilities implementation
          * It converts cached capability json document as gml+xml style
@@ -46,9 +48,12 @@ namespace eows
         class get_capabilities : public eows::ogc::wcs::core::operation
         {
           public:
-            get_capabilities();
+            get_capabilities(const get_capabilities_request&);
             ~get_capabilities();
 
+            /**
+             * @brief Prepares XML encoder in order to generate WCS GetCapabilities
+             */
             void execute();
 
             /**
@@ -57,8 +62,14 @@ namespace eows
              */
             const char* content_type() const;
 
+            /**
+             * @brief Retrieves XML string representation of WCS GetCapabilities 2.0
+             * @return
+             */
             const std::string to_string() const override;
           private:
+            struct impl;
+            impl* pimpl_;
         };
       }
     }

--- a/src/eows/ogc/wcs/wcs.cpp
+++ b/src/eows/ogc/wcs/wcs.cpp
@@ -46,7 +46,7 @@ void eows::ogc::wcs::handler::do_get(const eows::core::http_request& req,
 
   try
   {
-    const eows::ogc::wcs::core::operation* op = operations::build_operation(qstr);
+    std::unique_ptr<eows::ogc::wcs::core::operation> op(operations::build_operation(qstr));
     std::string output = op->to_string();
 
     res.set_status(eows::core::http_response::OK);

--- a/src/eows/ogc/wcs/wcs.cpp
+++ b/src/eows/ogc/wcs/wcs.cpp
@@ -42,7 +42,7 @@
 void eows::ogc::wcs::handler::do_get(const eows::core::http_request& req,
                                      eows::core::http_response& res)
 {
-  eows::core::query_string_t qstr(req.query_string());
+  eows::core::query_string_t qstr = eows::ogc::wcs::core::lowerify(req.query_string());
 
   try
   {
@@ -56,7 +56,7 @@ void eows::ogc::wcs::handler::do_get(const eows::core::http_request& req,
   }
   catch(const std::exception& e)
   {
-    std::string output = "ERROR. TEST";
+    std::string output = e.what();
 
     res.set_status(eows::core::http_response::bad_request);
     res.add_header(eows::core::http_response::CONTENT_TYPE, "text/plain; charset=utf-8");

--- a/src/eows/ogc/wcs/wcs.hpp
+++ b/src/eows/ogc/wcs/wcs.hpp
@@ -50,7 +50,7 @@ namespace eows
         void do_get(const eows::core::http_request& req,
                     eows::core::http_response& res);
       };
-    
+
       //! Initialize the service.
       void initialize();
 


### PR DESCRIPTION
Ticket: #5 

With these changes, you can retrieve WCS GetCapabilities xml based on `share/eows/wcs.json` document.


#### Test
As WCS 2.0 there is no official client and even stable, you should download [QGIS](https://www.qgis.org/en/site/forusers/alldownloads.html) and install plugin [QgsWcsClient2](https://plugins.qgis.org/plugins/QgsWcsClient2/). Once downloaded, run EOWS server `/path/to/eows-install/bin/eows-app-server` and open QGIS.
Select **QgsWcsClient2** in **Plugins** bar and add a new server: 
  - Name: **EOWS-Server**
  - URL:  **[http://127.0.0.1:7654/wcs?](http://127.0.0.1:7654/wcs?)**
Connect and in **GetCapabilities** bar, click in `Get Capabilities`