### PR TITLE
Adding support CI Server

### DIFF
--- a/build/scripts/Dockerfile
+++ b/build/scripts/Dockerfile
@@ -33,6 +33,7 @@ ARG host_ip=127.0.0.1
 ARG net_mask=$host_ip/8
 ARG scidb_usr=scidb
 ARG dev_dir=/home/$scidb_usr/mydevel
+ARG SCIDB_PASS=scidb
 ARG EOWS_PATH=$dev_dir/eows
 ARG EOWS_DEPENDENCIES_DIR=$EOWS_PATH/3rdparty
 ARG EOWS_CODEBASE=$EOWS_PATH/codebase
@@ -41,6 +42,9 @@ ARG EOWS_INSTALL_DIR=$EOWS_PATH/install
 
 RUN groupadd $scidb_usr
 RUN useradd $scidb_usr -s /bin/bash -m -g $scidb_usr
+# Defining SciDB credential to connect
+RUN echo $scidb_usr:$SCIDB_PASS | chpasswd
+
 RUN mkdir /home/$scidb_usr/mydevel
 RUN chown $scidb_usr:$scidb_usr $dev_dir
 

--- a/build/scripts/Dockerfile
+++ b/build/scripts/Dockerfile
@@ -153,6 +153,14 @@ RUN chmod +x /docker-entrypoint.sh
 
 # Adding special sudo power to scidb user due EOWS 3rdparty libraries used apt-get install
 RUN echo "scidb ALL=(ALL) NOPASSWD: /usr/bin/apt-get" >> /etc/sudoers
+RUN echo "scidb ALL=(ALL) NOPASSWD: /usr/bin/make" >> /etc/sudoers
+
+RUN cmake --version
+RUN apt-get remove cmake* -y
+RUN apt-get install curl
+
+# Removing Broken header SciDB
+RUN sed -i '/**MurmurHash3.h/c\//MurmurHash3 has been removed' $SCIDB_INSTALL_PATH/include/util/Hashing.h
 
 USER $scidb_usr
 # Creating EOWS dev dir
@@ -162,14 +170,20 @@ RUN mkdir -p $EOWS_DEPENDENCIES_DIR $EOWS_CODEBASE $EOWS_BUILD_DIR $EOWS_INSTALL
 WORKDIR $EOWS_CODEBASE
 RUN git clone https://github.com/eows/eows.git .
 
-WORKDIR $EOWS_DEPENDENCIES_DIR
+WORKDIR $EOWS_DEPENDENCIES_DIR  
 RUN cp $EOWS_CODEBASE/bash/install-3rdparty-linux-ubuntu-14.04.sh .
 RUN wget http://www.dpi.inpe.br/foss/eows/eows-3rdparty-0.3.0-linux-ubuntu-14.04.tar.gz
+RUN curl -O https://raw.githubusercontent.com/raphaelrpl/eows/fix_scripts/bash/install-3rdparty-linux-ubuntu-14.04.sh
+RUN chmod +x install-3rdparty-linux-ubuntu-14.04.sh
 # Compile Dependendies
 RUN ./install-3rdparty-linux-ubuntu-14.04.sh $EOWS_DEPENDENCIES_DIR
 
-USER root
+# Testing PreCompilation
+WORKDIR $EOWS_BUILD_DIR
+RUN cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE="Release" -DCMAKE_PREFIX_PATH="$SCIDB_INSTALL_PATH;/opt/scidb/15.12/3rdparty/boost;$EOWS_DEPENDENCIES_DIR" $EOWS_CODEBASE/build/cmake
+RUN make -j 2
 
+WORKDIR /home/$scidb_usr
 ## Starting SciDB and compile EOWS dependencies
 ## ---
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/build/scripts/Dockerfile
+++ b/build/scripts/Dockerfile
@@ -1,0 +1,175 @@
+## 
+##  Copyright (C) 2017 National Institute For Space Research (INPE) - Brazil.
+##  This file is part of Earth Observation Web Services (EOWS).
+##  EOWS is free software: you can redistribute it and/or modify
+##  it under the terms of the GNU General Public License version 3 as
+##  published by the Free Software Foundation.
+##  EOWS is distributed  "AS-IS" in the hope that it will be useful,
+##  but WITHOUT ANY WARRANTY OF ANY KIND; without even the implied warranty
+##  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+##  GNU Lesser General Public License for more details.
+##  You should have received a copy of the GNU Lesser General Public License
+##  along with EOWS. See LICENSE. If not, write to
+##  e-sensing team at <esensing-team@dpi.inpe.br>.
+##
+## Description
+## ---
+## It creates a environment for Continuous Integration Server (Jenkins). It installs SciDB 15.12
+## and install EOWS 3rdparty dependencies
+##
+
+## ===
+## Based in rvernica/scidb-example https://github.com/rvernica/scidb-examples/tree/master/docker-image
+
+## Requirements
+## ---
+FROM ubuntu:14.04
+RUN apt-get update
+RUN apt-get install -y wget apt-transport-https software-properties-common
+
+## Installation Notes
+## ---
+ARG host_ip=127.0.0.1
+ARG net_mask=$host_ip/8
+ARG scidb_usr=scidb
+ARG dev_dir=/home/$scidb_usr/mydevel
+ARG EOWS_PATH=$dev_dir/eows
+ARG EOWS_DEPENDENCIES_DIR=$EOWS_PATH/3rdparty
+ARG EOWS_CODEBASE=$EOWS_PATH/codebase
+ARG EOWS_BUILD_DIR=$EOWS_PATH/build
+ARG EOWS_INSTALL_DIR=$EOWS_PATH/install
+
+RUN groupadd $scidb_usr
+RUN useradd $scidb_usr -s /bin/bash -m -g $scidb_usr
+RUN mkdir /home/$scidb_usr/mydevel
+RUN chown $scidb_usr:$scidb_usr $dev_dir
+
+## Pre-Installation Tasks
+## ===
+## https://paradigm4.atlassian.net/wiki/display/ESD/Pre-Installation+Tasks
+
+## Download SciDB Community Edition
+## ---
+WORKDIR $dev_dir
+ARG scidb_url="https://docs.google.com/uc?id=0B7yt0n33Us0raWtCYmNlZWRxWG8&export=download"
+RUN wget --no-verbose --output-document scidb-15.12.1.4cadab5.tar.gz \
+        --load-cookies cookies.txt \
+        "$scidb_url&`wget --no-verbose --output-document - \
+            --save-cookies cookies.txt "$scidb_url" | \
+            grep --only-matching 'confirm=[^&]*'`"
+RUN tar -xzf scidb-15.12.1.4cadab5.tar.gz
+RUN mv scidb-15.12.1.4cadab5 scidbtrunk
+WORKDIR $dev_dir/scidbtrunk
+
+## Installing Expect, and SSH Packages
+## --
+RUN apt-get install -y expect openssh-server openssh-client git wget
+
+## Providing Passwordless SSH
+## ---
+RUN ssh-keygen -f /root/.ssh/id_rsa -N ''
+RUN chmod 755 /root
+RUN chmod 755 /root/.ssh
+
+RUN mkdir /home/$scidb_usr/.ssh
+RUN ssh-keygen -f /home/$scidb_usr/.ssh/id_rsa -N ''
+RUN chmod 755 /home/$scidb_usr
+RUN chmod 755 /home/$scidb_usr/.ssh
+
+## Avoid setting password and providing it to "deploy.sh access"
+RUN cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+RUN cat /root/.ssh/id_rsa.pub >> /home/$scidb_usr/.ssh/authorized_keys
+
+## Set correct ownership
+RUN chown -R $scidb_usr:$scidb_usr /home/$scidb_usr
+
+RUN service ssh start && \
+    ./deployment/deploy.sh access root NA "" $host_ip && \
+    ./deployment/deploy.sh access $scidb_usr NA "" $host_ip && \
+    ssh $host_ip date
+
+## Installing Build Tools
+## ---
+RUN service ssh start && \
+    ./deployment/deploy.sh prepare_toolchain $host_ip
+
+## Installing Postgres
+## ---
+RUN service ssh start && \
+    ./deployment/deploy.sh prepare_postgresql postgres postgres $net_mask $host_ip
+
+## Providing the postgres user Access to SciDB Code
+RUN usermod -G $scidb_usr -a postgres
+RUN chmod g+rx $dev_dir
+RUN /usr/bin/sudo -u postgres ls $dev_dir
+
+
+## Installing SciDB Community Edition
+## ===
+## https://paradigm4.atlassian.net/wiki/display/ESD/Installing+SciDB+Community+Edition
+
+## Configuring Environment Variables
+## ---
+ENV SCIDB_VER=15.12
+ENV SCIDB_INSTALL_PATH=$dev_dir/scidbtrunk/stage/install
+ENV SCIDB_BUILD_TYPE=Debug
+ENV PATH=$SCIDB_INSTALL_PATH/bin:$PATH
+
+RUN echo "\
+export SCIDB_VER=$SCIDB_VER\n\
+export SCIDB_INSTALL_PATH=$SCIDB_INSTALL_PATH\n\
+export SCIDB_BUILD_TYPE=$SCIDB_BUILD_TYPE\n\
+export PATH=$PATH\n" | tee /root/.bashrc > /home/$scidb_usr/.bashrc
+
+
+### Activating and Verifying the New .bashrc File
+RUN echo $SCIDB_VER
+RUN echo $SCIDB_INSTALL_PATH
+RUN echo $PATH
+
+## Building SciDB CE
+## ---
+RUN ./run.py setup --force
+RUN ./run.py make -j4
+
+## Installing SciDB CE
+## ---
+RUN service ssh start && \
+    service postgresql start && \
+    echo "\n\ny" | ./run.py install --force
+
+
+## Starting and Stopping SciDB
+## ===
+## https://paradigm4.atlassian.net/wiki/display/ESD/Starting+and+Stopping+SciDB
+
+RUN echo "#!/bin/bash\n\
+service ssh start\n\
+service postgresql start\n\
+scidb.py startall mydb\n\
+trap \"scidb.py stopall mydb; service postgresql stop\" EXIT HUP INT QUIT TERM\n\
+bash" > /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+# Adding special sudo power to scidb user due EOWS 3rdparty libraries used apt-get install
+RUN echo "scidb ALL=(ALL) NOPASSWD: /usr/bin/apt-get" >> /etc/sudoers
+
+USER $scidb_usr
+# Creating EOWS dev dir
+RUN mkdir -p $EOWS_DEPENDENCIES_DIR $EOWS_CODEBASE $EOWS_BUILD_DIR $EOWS_INSTALL_DIR
+
+# Download EOWS
+WORKDIR $EOWS_CODEBASE
+RUN git clone https://github.com/eows/eows.git .
+
+WORKDIR $EOWS_DEPENDENCIES_DIR
+RUN cp $EOWS_CODEBASE/bash/install-3rdparty-linux-ubuntu-14.04.sh .
+RUN wget http://www.dpi.inpe.br/foss/eows/eows-3rdparty-0.3.0-linux-ubuntu-14.04.tar.gz
+# Compile Dependendies
+RUN ./install-3rdparty-linux-ubuntu-14.04.sh $EOWS_DEPENDENCIES_DIR
+
+USER root
+
+## Starting SciDB and compile EOWS dependencies
+## ---
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/build/scripts/Dockerfile
+++ b/build/scripts/Dockerfile
@@ -201,4 +201,7 @@ RUN make -j 2
 WORKDIR /home/$scidb_usr
 ## Starting SciDB and compile EOWS dependencies
 ## ---
-ENTRYPOINT ["/docker-entrypoint.sh"]
+# ENTRYPOINT ["/docker-entrypoint.sh"]
+# FIX: Jenkins Docker plugins does not start container properly when pass a entrypoint like /docker-entrypoint.sh. We must investigate it.
+# In order to get through it, we expose only uptime execution
+CMD uptime

--- a/build/scripts/Dockerfile
+++ b/build/scripts/Dockerfile
@@ -155,14 +155,26 @@ RUN chmod +x /docker-entrypoint.sh
 RUN echo "scidb ALL=(ALL) NOPASSWD: /usr/bin/apt-get" >> /etc/sudoers
 RUN echo "scidb ALL=(ALL) NOPASSWD: /usr/bin/make" >> /etc/sudoers
 
+# Remove CMake 2.8X
 RUN cmake --version
 RUN apt-get remove cmake* -y
 RUN apt-get install curl
 
+# Install CMake 3.7.2
+ARG CMAKE_SRC_DIR=$dev_dir/cmake
+WORKDIR $CMAKE_SRC_DIR
+
+RUN curl -O https://cmake.org/files/v3.7/cmake-3.7.2.tar.gz
+RUN tar -zxf cmake-3.7.2.tar.gz
+WORKDIR $CMAKE_SRC_DIR/cmake-3.7.2
+RUN ./configure
+RUN make && make install
+
+#
 # Removing Broken header SciDB
+#
 RUN sed -i '/**MurmurHash3.h/c\//MurmurHash3 has been removed' $SCIDB_INSTALL_PATH/include/util/Hashing.h
 
-USER $scidb_usr
 # Creating EOWS dev dir
 RUN mkdir -p $EOWS_DEPENDENCIES_DIR $EOWS_CODEBASE $EOWS_BUILD_DIR $EOWS_INSTALL_DIR
 
@@ -172,8 +184,7 @@ RUN git clone https://github.com/eows/eows.git .
 
 WORKDIR $EOWS_DEPENDENCIES_DIR  
 RUN cp $EOWS_CODEBASE/bash/install-3rdparty-linux-ubuntu-14.04.sh .
-RUN wget http://www.dpi.inpe.br/foss/eows/eows-3rdparty-0.3.0-linux-ubuntu-14.04.tar.gz
-RUN curl -O https://raw.githubusercontent.com/raphaelrpl/eows/fix_scripts/bash/install-3rdparty-linux-ubuntu-14.04.sh
+RUN curl -O http://www.dpi.inpe.br/foss/eows/eows-3rdparty-0.3.0-linux-ubuntu-14.04.tar.gz
 RUN chmod +x install-3rdparty-linux-ubuntu-14.04.sh
 # Compile Dependendies
 RUN ./install-3rdparty-linux-ubuntu-14.04.sh $EOWS_DEPENDENCIES_DIR

--- a/build/scripts/README.md
+++ b/build/scripts/README.md
@@ -5,3 +5,5 @@ Jenkins - [Link](http://www.dpi.inpe.br/jenkins/view/eows/)
 ## Structure
 
 - **Dockerfile** - Represents a Docker configuration to generate a ubuntu 14.04 image with SciDB and EOWS 3rdparty dependencies installation;
+- **build.sh** - Represents a bash script to compile EOWS on Linux Ubuntu 14.04;
+- **eows.conf.cmake** - Represents a EOWS CMake cache options for compilation.

--- a/build/scripts/README.md
+++ b/build/scripts/README.md
@@ -1,0 +1,7 @@
+# Continuous Integration
+
+Jenkins - [Link](http://www.dpi.inpe.br/jenkins/view/eows/)
+
+## Structure
+
+- **Dockerfile** - Represents a Docker configuration to generate a ubuntu 14.04 image with SciDB and EOWS 3rdparty dependencies installation;

--- a/build/scripts/build.sh
+++ b/build/scripts/build.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2017 National Institute For Space Research (INPE) - Brazil.
+#
+# This file is part of Earth Observation Web Services (EOWS).
+#
+# EOWS is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# EOWS is distributed  "AS-IS" in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY OF ANY KIND; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with EOWS. See LICENSE. If not, write to
+# e-sensing team at <esensing-team@dpi.inpe.br>.
+
+#
+# Description: This script compile EOWS in Linux Ubuntu 14.04 and 16.04 systems.
+#
+# Author: Raphael Willian da Costa
+#
+# Usage: cd build/scripts && ./build.sh
+#
+
+#
+# Defining constants to help during compile process
+#
+# EOWS_CODEBASE - Points to Codebase root. You may export it before if need expose it outside codebase path
+if [ -z "$EOWS_CODEBASE" ]; then
+  export EOWS_CODEBASE=`pwd`/../..
+fi
+
+# EOWS_3RDPARTY - Points to EOWS 3rdparties.
+if [ -z "$EOWS_3RDPARTY" ]; then
+  export EOWS_3RDPARTY="$HOME/mydevel/eows/3rdparty"
+fi
+
+# EOWS_BOOST_DIR - Points to EOWS 3rdparties.
+if [ -z "$EOWS_BOOST_DIR" ]; then
+  export EOWS_BOOST_DIR="/opt/scidb/15.12/3rdparty/boost"
+fi
+
+# EOWS_SCIDB_DIR - Path to SciDB installation
+if [ -z "$EOWS_SCIDB_DIR" ]; then
+  export EOWS_SCIDB_DIR="/home/scidb/mydevel/scidbtrunk/stage/install"
+fi
+
+# EOWS_BUILD_DIR - Path to EOWS build.
+if [ -z "$EOWS_BUILD_DIR" ]; then
+  export EOWS_BUILD_DIR="$EOWS_CODEBASE/../build-cmake"
+fi
+
+# Creating target directory
+mkdir -p $EOWS_BUILD_DIR
+# Copying EOWS cache to target directory
+cp $EOWS_CODEBASE/build/scripts/eows.conf.cmake $EOWS_BUILD_DIR
+
+cd $EOWS_BUILD_DIR
+# Generate Build makefiles
+cmake -G "Unix Makefiles" -C eows.conf.cmake \
+                             -DCMAKE_BUILD_TYPE="Release" \
+                             $EOWS_CODEBASE/build/cmake
+
+# Compile
+make -j 4
+
+exit $?

--- a/build/scripts/eows.conf.cmake
+++ b/build/scripts/eows.conf.cmake
@@ -1,0 +1,6 @@
+# Configuring CMake global values
+set(CMAKE_PREFIX_PATH "$ENV{EOWS_3RDPARTY};$ENV{EOWS_SCIDB_DIR};$ENV{EOWS_BOOST_DIR}" CACHE STRING "Path to Libraries" FORCE)
+
+# Turning on EOWS flags
+set(EOWS_GEOARRAY_ENABLED ON CACHE BOOL "Build GeoArray module?" FORCE)
+


### PR DESCRIPTION
## Overview
This PR aims to introduce a EOWS continuous integration with Jenkins available in http://www.dpi.inpe.br/jenkins.

These changes include a Dockerfile that compiles SciDB 15.12 and EOWS dependencies as container. In this way, its not necessary to install on real machine. As SciDB is too big, I could not upload image to [DockerHub](https://hub.docker.com/) due network restrictions it would take long time. It also includes build script files **build.sh** and **eows.conf.cmake** inside `build/scripts` to enable build modification.

## Usage
In CI Server, you must build EOWS docker image (After Merged).

```bash
git clone https://github.com/eows/eows.git
cd eows/build/scripts
docker build --tag eows-scidb-15.12 .
```
Configure a new docker template in Jenkins and add the image created. **eows-scidb-15.12**

After these steps, run **build.sh** to compile. You may export variable values to customize build.
```bash
./build.sh
```