### PR TITLE
Using geoarray datatype to handle both GDAL and SciDB types

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ $ git clone http://github.com/eows/eows ~/eows/codebase
 EOWS is built on top of the following libraries:
 - [SciDB C++ API](http://www.paradigm4.com/): the SciDB development libraries and header files must be installed. For instance, in SciDB 15.12 the ```libscidbclient.so``` can be found at ```/opt/scidb/15.12/lib``` and the header files are located at ```/opt/scidb/15.12/include```.
 - [Boost Libraries](http://www.boost.org): we recommend to use the same version used and installed by SciDB (1.54.0). In general, it is installed under a folder such as ```/opt/scidb/15.12/3rdparty/boost```.
+- [GDAL](http://www.gdal.org): Geospatial Data Abstraction Library Version 2.13 or above is required.
 - [Proj.4](http://proj4.org): Cartographic projection library. Version 4.8.0 or above is required.
 - [RapidJSON](https://github.com/miloyip/rapidjson): a fast JSON parser for C++. Version 1.1.0 is required.
 - [Crow](https://github.com/ipkn/crow): a micro web framework in C++. Version. 

--- a/src/eows/core/utils.cpp
+++ b/src/eows/core/utils.cpp
@@ -90,6 +90,9 @@ eows::core::initialize()
   // Setting temporary data directory
   app_settings::instance().set_tmp_data_dir(temp_data_dir);
 
+  boost::format debug_msg("Using temporary data directory: %1%");
+  EOWS_LOG_INFO((debug_msg % app_settings::instance().get_tmp_data_dir()).str());
+
   EOWS_LOG_INFO("EOWS core runtime initialized!");
 }
 

--- a/src/eows/gdal/band.cpp
+++ b/src/eows/gdal/band.cpp
@@ -71,9 +71,6 @@ eows::gdal::band::band(eows::gdal::raster* parent, const std::size_t& id, GDALRa
 
   // TODO: Remove it.
   update_buffer_ = true;
-
-//  x_ = 0;//std::numeric_limits<int>::max();
-//  y_ = 0;//std::numeric_limits<int>::max();
 }
 
 eows::gdal::band::~band()
@@ -127,12 +124,8 @@ eows::gdal::property* eows::gdal::band::make_property(GDALRasterBand* gdalband, 
 
   std::unique_ptr<property> property_ptr(new property(index, property::from_gdal_datatype(gdalband->GetRasterDataType())));
 
-//  gdalband->GetBlockSize(&property_ptr->width, &property_ptr->height);
   property_ptr->width = gdalband->GetXSize();
   property_ptr->height = gdalband->GetYSize();
-
-//  property_ptr->block_x= (gdalband->GetXSize() + property_ptr->width - 1) / property_ptr->width;
-//  property_ptr->block_y = (gdalband->GetYSize() + property_ptr->height - 1) / property_ptr->height;
 
   return property_ptr.release();
 }
@@ -158,17 +151,3 @@ int eows::gdal::band::place_buffer(int col, int row)
 
   return (current_col_ + current_row_ * property_->width);
 }
-
-//void eows::gdal::band::read(std::size_t col, std::size_t row)
-//{
-//  if (update_buffer_)
-//  {
-//    write(col, row);
-//    x_ = col;
-//    y_ = row;
-//  }
-
-//  CPLErr flag = gdal_->ReadBlock(col, row, buffer_);
-//  if (flag != CE_None)
-//    EOWS_LOG_ERROR("Could not read dataset block " + std::to_string(col) + " - " + "row");
-//}

--- a/src/eows/gdal/band.cpp
+++ b/src/eows/gdal/band.cpp
@@ -18,7 +18,7 @@
  */
 
 /*!
-  \file eows/gdal/band.hpp
+  \file eows/gdal/band.cpp
 
   \brief Implementation of Raster band
 

--- a/src/eows/gdal/band.cpp
+++ b/src/eows/gdal/band.cpp
@@ -64,6 +64,10 @@ eows::gdal::band::band(eows::gdal::raster* parent, const std::size_t& id, GDALRa
       getter_ = eows::gdal::get_int32;
       setter_ = eows::gdal::set_int32;
       break;
+    case GDT_UInt32:
+      getter_ = eows::gdal::get_uint32;
+      setter_ = eows::gdal::set_uint32;
+      break;
     default: // GDT_Unknown
       getter_ = eows::gdal::get_int8;
       setter_ = eows::gdal::set_int8;
@@ -100,7 +104,6 @@ void eows::gdal::band::get_value(const std::size_t& x, const std::size_t& y, dou
 void eows::gdal::band::set_value(const std::size_t& x, const std::size_t& y, double v)
 {
   current_i_ = place_buffer(x, y);
-
   setter_(current_i_, buffer_, &v);
 }
 

--- a/src/eows/gdal/band.hpp
+++ b/src/eows/gdal/band.hpp
@@ -91,7 +91,6 @@ namespace eows
          * \return Index to insert
          */
         int place_buffer(int col, int row);
-//        void read(std::size_t col, std::size_t row);
 
       private:
         std::size_t id_; //!< Band id

--- a/src/eows/gdal/data_types.hpp
+++ b/src/eows/gdal/data_types.hpp
@@ -2,6 +2,9 @@
 #define __EOWS_GDAL_DATA_TYPES_HPP__
 
 #include "exception.hpp"
+
+#include "../geoarray/data_types.hpp"
+
 #include <gdal_priv.h>
 
 namespace eows
@@ -9,32 +12,17 @@ namespace eows
   namespace gdal
   {
     /*!
-     * \brief EOWS GDAL Data type representation
-     */
-    enum class datatype
-    {
-      int8,   //!< Integer 8 bits (stl int8_t)
-      uint8,  //!< Unsigned Integer 8 bits (stl uint8_t)
-      int16,  //!< Integer 2 bytes (stl int16_t)
-      uint16, //!< Unsigned Integer 2 bytes (stl uint16_t)
-      int32,  //!< Integer 4 bytes (stl int32_t)
-      uint32  //!< Unsigned Integer 4 bytes (stl uint32_t)
-    };
-
-    /*!
      * \brief Defines a EOWS Raster Band property containing metadata information like dummy value, eows data type, etc.
      */
     struct property
     {
       std::size_t index; //!< Property index (same band)
-      datatype dtype;    //!< Band datatype definition
+      int dtype;         //!< Band datatype definition
       double dummy;      //!< Dummy value for band
       int width;         //!< Band width
       int height;        //!< Band height
-//      int block_x;       //!< Defines block position of axis X. Used for cache handling
-//      int block_y;       //!< Defines block position of axis Y. Used for cache handling
 
-      property(const std::size_t i, datatype t)
+      property(const std::size_t i, int t)
         : index(i), dtype(t), dummy(-9999), width(0), height(0)
       {
       }
@@ -44,20 +32,24 @@ namespace eows
        * \param dt - GDAL datatype
        * \return Band datatype
        */
-      static datatype from_gdal_datatype(GDALDataType dt)
+      static int from_gdal_datatype(GDALDataType dt)
       {
         switch(dt)
         {
           case GDT_Byte:
-            return datatype::int8;
+            return eows::geoarray::datatype_t::int8_dt;
           case GDT_Int16:
-            return datatype::int16;
+            return eows::geoarray::datatype_t::int16_dt;
           case GDT_UInt16:
-            return datatype::uint16;
+            return eows::geoarray::datatype_t::uint16_dt;
           case GDT_Int32:
-            return datatype::int32;
+            return eows::geoarray::datatype_t::int32_dt;
           case GDT_UInt32:
-            return datatype::uint32;
+            return eows::geoarray::datatype_t::uint32_dt;
+          case GDT_Float32:
+            return eows::geoarray::datatype_t::float_dt;
+          case GDT_Float64:
+            return eows::geoarray::datatype_t::double_dt;
           default:
           {
             throw gdal_error("Invalid GDAL datatype");
@@ -70,20 +62,24 @@ namespace eows
        * \param dt - EOWS GDAL data type
        * \return GDAL data type
        */
-      static GDALDataType from_datatype(datatype dt)
+      static GDALDataType from_datatype(int dt)
       {
         switch(dt)
         {
-          case datatype::int8:
+          case eows::geoarray::datatype_t::int8_dt:
             return GDT_Byte;
-          case datatype::int16:
+          case eows::geoarray::datatype_t::int16_dt:
             return GDT_Int16;
-          case datatype::uint16:
+          case eows::geoarray::datatype_t::uint16_dt:
             return GDT_UInt16;
-          case datatype::int32:
+          case eows::geoarray::datatype_t::int32_dt:
             return GDT_Int32;
-          case datatype::uint32:
+          case eows::geoarray::datatype_t::uint32_dt:
             return GDT_Int32;
+          case eows::geoarray::datatype_t::float_dt:
+            return GDT_Float32;
+          case eows::geoarray::datatype_t::double_dt:
+            return GDT_Float64;
           default:
           {
             throw gdal_error("Invalid datatype");

--- a/src/eows/gdal/data_types.hpp
+++ b/src/eows/gdal/data_types.hpp
@@ -1,3 +1,30 @@
+/*
+  Copyright (C) 2017 National Institute For Space Research (INPE) - Brazil.
+
+  This file is part of Earth Observation Web Services (EOWS).
+
+  EOWS is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License version 3 as
+  published by the Free Software Foundation.
+
+  EOWS is distributed  "AS-IS" in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY OF ANY KIND; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with EOWS. See LICENSE. If not, write to
+  e-sensing team at <esensing-team@dpi.inpe.br>.
+ */
+
+/*!
+  \file eows/gdal/data_types.hpp
+
+  \brief Represents useful datatypes for GDAL handling
+
+  \author Raphael Willian da Costa
+ */
+
 #ifndef __EOWS_GDAL_DATA_TYPES_HPP__
 #define __EOWS_GDAL_DATA_TYPES_HPP__
 

--- a/src/eows/gdal/raster.cpp
+++ b/src/eows/gdal/raster.cpp
@@ -97,6 +97,12 @@ void eows::gdal::raster::close()
     GDALClose(static_cast<GDALDatasetH>(dataset_));
     dataset_ = nullptr;
   }
+
+  if (metadata_ != nullptr)
+  {
+    CSLDestroy(metadata_);
+    metadata_ = nullptr;
+  }
 }
 
 eows::gdal::band* eows::gdal::raster::get_band(const std::size_t& id) const

--- a/src/eows/gdal/utils.cpp
+++ b/src/eows/gdal/utils.cpp
@@ -1,3 +1,30 @@
+/*
+  Copyright (C) 2017 National Institute For Space Research (INPE) - Brazil.
+
+  This file is part of Earth Observation Web Services (EOWS).
+
+  EOWS is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License version 3 as
+  published by the Free Software Foundation.
+
+  EOWS is distributed  "AS-IS" in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY OF ANY KIND; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with EOWS. See LICENSE. If not, write to
+  e-sensing team at <esensing-team@dpi.inpe.br>.
+ */
+
+/*!
+  \file eows/gdal/utils.cpp
+
+  \brief Implementation of EOWS GDAL utility
+
+  \author Raphael Willian da Costa
+ */
+
 #include "utils.hpp"
 #include "../core/logger.hpp"
 #include "../geoarray/data_types.hpp"

--- a/src/eows/gdal/utils.cpp
+++ b/src/eows/gdal/utils.cpp
@@ -1,5 +1,6 @@
 #include "utils.hpp"
 #include "../core/logger.hpp"
+#include "../geoarray/data_types.hpp"
 
 #include <gdal_priv.h>
 
@@ -11,27 +12,9 @@ void eows::gdal::initialize()
   EOWS_LOG_INFO("EOWS Gdal initialized.");
 }
 
-int eows::gdal::pixel_size(eows::gdal::datatype dt)
+int eows::gdal::pixel_size(int dt)
 {
-  if (dt == datatype::int8)
-    return sizeof(char) * 8;
-
-  if (dt == datatype::uint8)
-    return sizeof(unsigned char);
-
-  if (dt == datatype::int16)
-    return sizeof(int16_t);
-
-  if (dt == datatype::int32)
-    return sizeof(int32_t);
-
-  if (dt == datatype::uint16)
-    return sizeof(uint16_t);
-
-  if (dt == datatype::uint32)
-    return sizeof(uint32_t);
-
-  return 1;
+  return eows::geoarray::datatype_t::bytes(dt);
 }
 
 void eows::gdal::get_int8(int index, void* buffer, double* value)

--- a/src/eows/gdal/utils.cpp
+++ b/src/eows/gdal/utils.cpp
@@ -69,6 +69,11 @@ void eows::gdal::get_uint8(int index, void* buffer, double* value)
   *value = static_cast<double>(static_cast<uint8_t*>(buffer)[index]);
 }
 
+void eows::gdal::get_uint32(int index, void* buffer, double* value)
+{
+  *value = static_cast<double>(static_cast<uint32_t*>(buffer)[index]);
+}
+
 void eows::gdal::set_uint8(int index, void* buffer, double* value)
 {
   static_cast<uint8_t*>(buffer)[index] = static_cast<uint8_t>(*value);
@@ -92,4 +97,9 @@ void eows::gdal::set_uint16(int index, void* buffer, double* value)
 void eows::gdal::set_int32(int index, void* buffer, double* value)
 {
   static_cast<int32_t*>(buffer)[index] = static_cast<int32_t>(*value);
+}
+
+void eows::gdal::set_uint32(int index, void* buffer, double* value)
+{
+  static_cast<uint32_t*>(buffer)[index] = static_cast<uint32_t>(*value);
 }

--- a/src/eows/gdal/utils.hpp
+++ b/src/eows/gdal/utils.hpp
@@ -1,3 +1,30 @@
+/*
+  Copyright (C) 2017 National Institute For Space Research (INPE) - Brazil.
+
+  This file is part of Earth Observation Web Services (EOWS).
+
+  EOWS is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License version 3 as
+  published by the Free Software Foundation.
+
+  EOWS is distributed  "AS-IS" in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY OF ANY KIND; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with EOWS. See LICENSE. If not, write to
+  e-sensing team at <esensing-team@dpi.inpe.br>.
+ */
+
+/*!
+  \file eows/gdal/utils.hpp
+
+  \brief Defins EOWS GDAL utility
+
+  \author Raphael Willian da Costa
+ */
+
 #ifndef __EOWS_GDAL_UTILS_HPP__
 #define __EOWS_GDAL_UTILS_HPP__
 

--- a/src/eows/gdal/utils.hpp
+++ b/src/eows/gdal/utils.hpp
@@ -111,6 +111,21 @@ namespace eows
     void set_int32(int index, void* buffer, double* value);
 
     /*!
+     * \brief Reads an uint32 type from buffer
+     * \param index - Buffer index
+     * \param buffer - Buffer
+     * \param value - Variable to store value
+     */
+    void get_uint32(int index, void* buffer, double* value);
+    /*!
+     * \brief It sets an uint32 value to buffer
+     * \param index - Buffer index
+     * \param buffer - Buffer
+     * \param value - Value to append
+     */
+    void set_uint32(int index, void* buffer, double* value);
+
+    /*!
      * \brief It retrieve real size of a datatype in bytes
      * \param dt Datatype
      * \return Size in bytes of a datatype

--- a/src/eows/gdal/utils.hpp
+++ b/src/eows/gdal/utils.hpp
@@ -88,7 +88,7 @@ namespace eows
      * \param dt Datatype
      * \return Size in bytes of a datatype
      */
-    int pixel_size(datatype dt);
+    int pixel_size(int dt);
   }
 }
 

--- a/src/eows/geoarray/data_types.hpp
+++ b/src/eows/geoarray/data_types.hpp
@@ -125,6 +125,35 @@ namespace eows
         }
       }
 
+      static inline int bytes(int dt)
+      {
+        switch(dt)
+        {
+          case eows::geoarray::datatype_t::int8_dt:
+            return sizeof(char) * 8;
+          case eows::geoarray::datatype_t::uint8_dt:
+            return sizeof(unsigned char);
+          case eows::geoarray::datatype_t::int16_dt:
+            return sizeof(int16_t);
+          case eows::geoarray::datatype_t::int32_dt:
+            return sizeof(int32_t);
+          case eows::geoarray::datatype_t::uint16_dt:
+            return sizeof(uint16_t);
+          case eows::geoarray::datatype_t::uint32_dt:
+            return sizeof(uint32_t);
+          case eows::geoarray::datatype_t::int64_dt:
+            return sizeof(int64_t);
+          case eows::geoarray::datatype_t::uint64_dt:
+            return sizeof(uint64_t);
+          case eows::geoarray::datatype_t::float_dt:
+            return sizeof(float);
+          case eows::geoarray::datatype_t::double_dt:
+            return sizeof(double);
+          default:
+            return 0;
+        }
+      }
+
       //! Convert a data type in its string description to its numeric code.
       static inline int from_string(const std::string& data_type_name)
       {

--- a/src/eows/ogc/wcs/core/data_types.hpp
+++ b/src/eows/ogc/wcs/core/data_types.hpp
@@ -77,7 +77,7 @@ namespace eows
         {
           static const std::string no_value; //!< Const flag to determine no value in specific axis
           std::string name; //!< Axis name
-          std::size_t srid; //!< Projection SRID (TODO: Implement it)
+          std::string srid; //!< Projection SRID (TODO: Implement it)
           std::string  min; //!< Axis minimum value
           std::string  max; //!< Axis maximum value
         };

--- a/src/eows/ogc/wcs/core/operation.hpp
+++ b/src/eows/ogc/wcs/core/operation.hpp
@@ -45,9 +45,7 @@ namespace eows
         class operation
         {
           public:
-            operation()
-            {
-            }
+            operation() = default;
 
             virtual ~operation()
             {

--- a/src/eows/ogc/wcs/operations/data_types.cpp
+++ b/src/eows/ogc/wcs/operations/data_types.cpp
@@ -95,7 +95,7 @@ eows::ogc::wcs::operations::get_coverage_request::get_coverage_request(const eow
   if (it == query.end())
     format = eows::core::APPLICATION_XML;
   else
-    format = eows::core::from_string(it->second); // It may throw exception (format non-supported)
+    format = eows::core::from_string(it->second);
 
   // InputCRS
   it = query.find("inputcrs");
@@ -175,7 +175,7 @@ void eows::ogc::wcs::operations::get_coverage_request::digest_subset(const eows:
         }
       }
       else
-        throw eows::ogc::wcs::invalid_axis_error("Invalid axis ");
+        throw eows::ogc::wcs::invalid_axis_error("Invalid axis while parsing " + dimension.name);
 
       subsets.push_back(dimension);
 

--- a/src/eows/ogc/wcs/operations/data_types.cpp
+++ b/src/eows/ogc/wcs/operations/data_types.cpp
@@ -142,7 +142,7 @@ void eows::ogc::wcs::operations::get_coverage_request::digest_subset(const eows:
 
       // Retrieve axis name
       char c;
-      while(ss >> c && c != '(')
+      while(ss >> c && (c != '(' && c != ','))
       {
         dimension.name += c;
         validate_subset(ss);
@@ -155,6 +155,16 @@ void eows::ogc::wcs::operations::get_coverage_request::digest_subset(const eows:
 
       if (found != subsets.end())
         throw eows::ogc::wcs::invalid_axis_error("Duplicated axis " + dimension.name);
+
+      // Checking if client informed SRS in axis
+      if (c == ',')
+      {
+        while(ss >> c && c != '(')
+        {
+          dimension.srid += c;
+          validate_subset(ss);
+        }
+      }
 
       while(ss >> c && (c != ',' && c != ')'))
       {

--- a/src/eows/ogc/wcs/operations/data_types.hpp
+++ b/src/eows/ogc/wcs/operations/data_types.hpp
@@ -48,7 +48,7 @@ namespace eows
       {
         /**
          * \brief It represents a base request structure for WCS access
-         * \throws
+         * \throws eows::ogc::missing_parameter_error when no service,version or request provided.
          */
         struct base_request
         {
@@ -56,12 +56,13 @@ namespace eows
 
           virtual ~base_request();
 
-          std::string request; //!< WCS rqeuest operation
+          std::string request; //!< WCS request operation
           std::string version; //!< WCS version
           std::string service; //!< WCS service name (Fixed to "WCS")
         };
         /**
          * \brief Represents a GetCapabilities request structure
+         * \throws eows::ogc::missing_parameter_error when required parameter no given.
          */
         struct get_capabilities_request : public base_request
         {
@@ -69,6 +70,7 @@ namespace eows
         };
         /**
          * \brief Represents DescriveCoverage Request structure
+         * \throws eows::ogc::missing_parameter_error when required parameter no given.
          */
         struct describe_coverage_request : public base_request
         {
@@ -77,6 +79,7 @@ namespace eows
         };
         /**
          * \brief Represents GetCoverage request structure
+         * \throws eows::ogc::missing_parameter_error when required parameter no given.
          */
         struct get_coverage_request : public base_request
         {
@@ -84,6 +87,7 @@ namespace eows
 
           /*!
            * \brief It process client subset and performs a minor validations like "already in" and syntax validation
+           * \throws eows::ogc::invalid_axis_error When could not parse axis in string representation
            * \param query - Query string
            */
           void digest_subset(const eows::core::query_string_t& query);

--- a/src/eows/ogc/wcs/operations/describe_coverage.cpp
+++ b/src/eows/ogc/wcs/operations/describe_coverage.cpp
@@ -198,8 +198,6 @@ void eows::ogc::wcs::operations::describe_coverage::execute()
   }
 
   rapidxml::print(std::back_inserter(pimpl_->xml_representation), xml_doc, 0);
-
-  EOWS_LOG_DEBUG(pimpl_->xml_representation);
 }
 
 const char*eows::ogc::wcs::operations::describe_coverage::content_type() const

--- a/src/eows/ogc/wcs/operations/factory.cpp
+++ b/src/eows/ogc/wcs/operations/factory.cpp
@@ -59,7 +59,7 @@ std::unique_ptr<eows::ogc::wcs::core::operation> eows::ogc::wcs::operations::bui
     op.reset(new describe_coverage(request));
     return std::move(op);
   }
-  else if (request_it->second == "GetCoverage")
+  else if (eows::core::to_lower(request_it->second) == "getcoverage")
   {
     get_coverage_request request(query);
     op.reset(new get_coverage(request));

--- a/src/eows/ogc/wcs/operations/get_coverage.cpp
+++ b/src/eows/ogc/wcs/operations/get_coverage.cpp
@@ -148,6 +148,9 @@ struct eows::ogc::wcs::operations::get_coverage::impl
 
   /*!
    * \brief It prepares Query result as GeoTIFF image.
+   *
+   * \throws eows::ogc::wcs::no_such_field_error When an attribute value is not supported by eows
+   *
    * \param cell_it SciDB array query result
    * \param array Geo array
    * \param attributes SciDB array attributes
@@ -162,8 +165,6 @@ struct eows::ogc::wcs::operations::get_coverage::impl
 
   //!< Represents WCS client arguments given. TODO: Use it as smart-pointer instead a const value
   const eows::ogc::wcs::operations::get_coverage_request request;
-  //!< Represents a cast of array/client subset in lat/long mode to Grid scale mode based in SRID
-  std::vector<eows::geoarray::dimension_t> grid_subset;
   //!< Represents Auto File remover for Image generation
   eows::core::file_remover_ptr file_handler;
   //!< Represents WCS GetCoverage output in GML format.

--- a/src/eows/ogc/wcs/operations/get_coverage.cpp
+++ b/src/eows/ogc/wcs/operations/get_coverage.cpp
@@ -232,22 +232,8 @@ void eows::ogc::wcs::operations::get_coverage::impl::process_as_tiff(boost::shar
   std::vector<eows::gdal::property> properties;
 
   for(const eows::geoarray::attribute_t& attribute: used_attributes)
-  {
-    const std::size_t index = cell_it->attribute_pos(attribute.name);
-    if (attribute.datatype == eows::geoarray::datatype_t::int16_dt)
-      properties.push_back(eows::gdal::property(index, eows::gdal::datatype::int16));
-    else if (attribute.datatype == eows::geoarray::datatype_t::uint16_dt)
-      properties.push_back(eows::gdal::property(index, eows::gdal::datatype::uint16));
-    else if (attribute.datatype == eows::geoarray::datatype_t::int8_dt)
-      properties.push_back(eows::gdal::property(index, eows::gdal::datatype::int8));
-    else if (attribute.datatype == eows::geoarray::datatype_t::uint8_dt)
-      properties.push_back(eows::gdal::property(index, eows::gdal::datatype::uint8));
-    else if (attribute.datatype == eows::geoarray::datatype_t::int32_dt)
-      properties.push_back(eows::gdal::property(index, eows::gdal::datatype::int32));
-    else
-      throw eows::ogc::wcs::no_such_field_error("Invalid attribute type, got " +
-                                                eows::geoarray::datatype_t::to_string(attribute.datatype));
-  }
+    properties.push_back(eows::gdal::property(cell_it->attribute_pos(attribute.name),
+                                              attribute.datatype));
 
   // Creating dataset
   file.create(tmp_file_path, x, y, properties);

--- a/src/eows/ogc/wcs/operations/get_coverage.cpp
+++ b/src/eows/ogc/wcs/operations/get_coverage.cpp
@@ -71,7 +71,6 @@
 // Boost
 #include <boost/shared_ptr.hpp>
 
-
 thread_local eows::proj4::spatial_ref_map t_srs_idx;
 
 // struct Impl implementation
@@ -106,10 +105,12 @@ struct eows::ogc::wcs::operations::get_coverage::impl
    * \brief It performs subset reprojection if client gives a SRID different from Geoarray native. After that, it checks
    * if latitude/longitude reprojected intersects with geoarray. Throws exception when it does not intersects.
    *
+   * \throws eows::ogc::wcs::invalid_axis_error When there is any axis invalid and dont intersects
+   * \throws std::runtime_error When could not reproject coordinate
+   *
    * \param srid - SRID to cast
    * \param latitude - Latitude value
    * \param longitude - Longitude value
-   * \throws eows::ogc::wcs::invalid_axis_error When there is any axis invalid and dont intersects
    */
   void validate(const std::size_t& srid, const eows::geoarray::spatial_extent_t& extent, double& latitude, double& longitude);
 
@@ -238,7 +239,6 @@ void eows::ogc::wcs::operations::get_coverage::impl::process_as_tiff(boost::shar
 
   // Creating dataset
   file.create(tmp_file_path, x, y, properties);
-
   // fill
   while(!cell_it->end())
   {
@@ -257,7 +257,7 @@ void eows::ogc::wcs::operations::get_coverage::impl::process_as_tiff(boost::shar
       else if (data_type == ::scidb::TID_UINT8)
         band->set_value(x, y, cell_it->get_uint8(name));
       else if (data_type == ::scidb::TID_INT16)
-        band->set_value(x, y, cell_it->get_uint16(name));
+        band->set_value(x, y, cell_it->get_int16(name));
       else if (data_type == ::scidb::TID_UINT16)
         band->set_value(x, y, cell_it->get_uint16(name));
       else if (data_type == ::scidb::TID_INT32)

--- a/src/eows/ogc/wcs/operations/get_coverage.cpp
+++ b/src/eows/ogc/wcs/operations/get_coverage.cpp
@@ -489,10 +489,14 @@ void eows::ogc::wcs::operations::get_coverage::impl::process_as_document(const e
 
       if (type_id == ::scidb::TID_INT16)
         ss << cell_it->get_int16(attr_scidb.getName());
+      if (type_id == ::scidb::TID_UINT16)
+        ss << cell_it->get_uint16(attr_scidb.getName());
       else if (type_id == ::scidb::TID_UINT8)
         ss << cell_it->get_uint8(attr_scidb.getName());
       else if (type_id == ::scidb::TID_INT8)
         ss << std::to_string(cell_it->get_int8(attr_scidb.getName()));
+      else if (type_id == ::scidb::TID_INT32)
+        ss << cell_it->get_int32(attr_scidb.getName());
 
       // TODO: Remove this check. It should append and remove last char on finish attr
       if (attr_pos + 1 < attributes_size)

--- a/src/eows/ogc/wcs/operations/get_coverage.cpp
+++ b/src/eows/ogc/wcs/operations/get_coverage.cpp
@@ -71,6 +71,7 @@
 // Boost
 #include <boost/shared_ptr.hpp>
 
+
 thread_local eows::proj4::spatial_ref_map t_srs_idx;
 
 // struct Impl implementation
@@ -135,14 +136,12 @@ struct eows::ogc::wcs::operations::get_coverage::impl
    * \brief It reads a SciDB query result as GML document. Once read, it prepares a WCS Coverage XML element with meta result
    * \param array - Current Geo Array
    * \param cell_it - SciDB Query Result
-   * \param array_attributes - SciDB Geo Array Attributes
    * \param used_extent - Array extent used for retrieving SciDB data
    * \param dimensions_query - Dimensions used to fetch query
    * \param attributes_query - Client Attributes used to fetch query
    */
   void process_as_document(const eows::geoarray::geoarray_t& array,
                            boost::shared_ptr<eows::scidb::cell_iterator> cell_it,
-                           const ::scidb::Attributes& array_attributes,
                            const eows::geoarray::spatial_extent_t& used_extent,
                            const std::vector<geoarray::dimension_t> dimensions_query,
                            const std::vector<geoarray::attribute_t>& attributes_query);
@@ -154,12 +153,10 @@ struct eows::ogc::wcs::operations::get_coverage::impl
    *
    * \param cell_it SciDB array query result
    * \param array Geo array
-   * \param attributes SciDB array attributes
    * \param dimensions An ordered dimensions used to Query(X, Y, T ...)
    */
   void process_as_tiff(boost::shared_ptr<eows::scidb::cell_iterator> cell_it,
                        const eows::geoarray::geoarray_t& array,
-                       const ::scidb::Attributes& attributes,
                        const std::vector<eows::geoarray::dimension_t> dimensions,
                        const geoarray::spatial_extent_t& used_extent,
                        const std::vector<geoarray::attribute_t>& used_attributes);
@@ -215,7 +212,6 @@ void eows::ogc::wcs::operations::get_coverage::impl::reproject(const std::size_t
 
 void eows::ogc::wcs::operations::get_coverage::impl::process_as_tiff(boost::shared_ptr<eows::scidb::cell_iterator> cell_it,
                                                                      const eows::geoarray::geoarray_t& array,
-                                                                     const ::scidb::Attributes& attributes,
                                                                      const std::vector<eows::geoarray::dimension_t> dimensions,
                                                                      const eows::geoarray::spatial_extent_t& used_extent,
                                                                      const std::vector<geoarray::attribute_t>& used_attributes)
@@ -239,31 +235,32 @@ void eows::ogc::wcs::operations::get_coverage::impl::process_as_tiff(boost::shar
 
   // Creating dataset
   file.create(tmp_file_path, x, y, properties);
+
+  const std::size_t attributes_size = used_attributes.size();
+
   // fill
   while(!cell_it->end())
   {
     const ::scidb::Coordinate& x = cell_it->get_position()[0] - dimension_x.min_idx;
     const ::scidb::Coordinate& y = cell_it->get_position()[1] - dimension_y.min_idx;
 
-    for(std::size_t index = 0; index < attributes.size(); ++index)
+    for(std::size_t index = 0; index < attributes_size; ++index)
     {
-      const ::scidb::AttributeDesc& attribute = attributes[index];
       eows::gdal::band* band = file.get_band(index);
-      const ::scidb::TypeId& data_type = attribute.getType();
-      const std::string& name = attribute.getName();
+      const eows::geoarray::attribute_t& attribute = used_attributes[index];
 
-      if (data_type == ::scidb::TID_INT8)
-        band->set_value(x, y, cell_it->get_int8(name));
-      else if (data_type == ::scidb::TID_UINT8)
-        band->set_value(x, y, cell_it->get_uint8(name));
-      else if (data_type == ::scidb::TID_INT16)
-        band->set_value(x, y, cell_it->get_int16(name));
-      else if (data_type == ::scidb::TID_UINT16)
-        band->set_value(x, y, cell_it->get_uint16(name));
-      else if (data_type == ::scidb::TID_INT32)
-        band->set_value(x, y, cell_it->get_int32(name));
+      if (attribute.datatype == eows::geoarray::datatype_t::int8_dt)
+        band->set_value(x, y, cell_it->get_int8(attribute.name));
+      else if (attribute.datatype == eows::geoarray::datatype_t::uint8_dt)
+        band->set_value(x, y, cell_it->get_uint8(attribute.name));
+      else if (attribute.datatype == eows::geoarray::datatype_t::int16_dt)
+        band->set_value(x, y, cell_it->get_int16(attribute.name));
+      else if (attribute.datatype == eows::geoarray::datatype_t::uint16_dt)
+        band->set_value(x, y, cell_it->get_uint16(attribute.name));
+      else if (attribute.datatype == eows::geoarray::datatype_t::int32_dt)
+        band->set_value(x, y, cell_it->get_int32(attribute.name));
       else // TODO
-        throw eows::ogc::wcs::no_such_field_error("Invalid attribute type, got " + data_type);
+        throw eows::ogc::wcs::no_such_field_error("Invalid attribute type, got " + eows::geoarray::datatype_t::to_string(attribute.datatype));
     }
 
     cell_it->next();
@@ -429,14 +426,14 @@ eows::ogc::wcs::operations::get_coverage::impl::retrieve_subsets(const eows::geo
       else
         throw eows::ogc::wcs::invalid_axis_error("No axis found. " + client_subset.name);
     } // end for
-  } // end if subsets.size()
 
-  validate(grid_array.geo_array->srid, grid_array.geo_array->i_meta.spatial_extent, ext.ymin, ext.xmin);
-  validate(grid_array.geo_array->srid, grid_array.geo_array->i_meta.spatial_extent, ext.ymin, ext.xmax);
-  output[0].min_idx = grid_array.col(ext.xmin);
-  output[0].max_idx = grid_array.col(ext.xmax);
-  output[1].min_idx = grid_array.row(ext.ymin);
-  output[1].max_idx = grid_array.row(ext.ymax);
+    validate(grid_array.geo_array->srid, grid_array.geo_array->i_meta.spatial_extent, ext.ymin, ext.xmin);
+    validate(grid_array.geo_array->srid, grid_array.geo_array->i_meta.spatial_extent, ext.ymax, ext.xmax);
+    output[0].min_idx = grid_array.col(ext.xmin);
+    output[0].max_idx = grid_array.col(ext.xmax);
+    output[1].min_idx = grid_array.row(ext.ymin);
+    output[1].max_idx = grid_array.row(ext.ymax);
+  } // end if subsets.size()
 
   extent.xmin = ext.xmin;
   extent.xmax = ext.xmax;
@@ -448,7 +445,6 @@ eows::ogc::wcs::operations::get_coverage::impl::retrieve_subsets(const eows::geo
 
 void eows::ogc::wcs::operations::get_coverage::impl::process_as_document(const eows::geoarray::geoarray_t& array,
                                                                          boost::shared_ptr<eows::scidb::cell_iterator> cell_it,
-                                                                         const ::scidb::Attributes& array_attributes,
                                                                          const eows::geoarray::spatial_extent_t& used_extent,
                                                                          const std::vector<eows::geoarray::dimension_t> dimensions_query,
                                                                          const std::vector<eows::geoarray::attribute_t>& attributes_query)
@@ -456,7 +452,7 @@ void eows::ogc::wcs::operations::get_coverage::impl::process_as_document(const e
   // Defining output stream where SciDB will be stored (GML format)
   std::ostringstream ss;
   // Retrieving Array size
-  auto attributes_size = array_attributes.size();
+  auto attributes_size = attributes_query.size();
   // Delimiter used in GML generation
   const std::string row_delimiter(",");
   const std::string attr_delimiter(" ");
@@ -470,20 +466,18 @@ void eows::ogc::wcs::operations::get_coverage::impl::process_as_document(const e
   {
     for(std::size_t attr_pos = 0; attr_pos < attributes_size; ++attr_pos)
     {
-      const ::scidb::AttributeDesc& attr_scidb = array_attributes[attr_pos];
+      const eows::geoarray::attribute_t& attribute = attributes_query[attr_pos];
 
-      const ::scidb::TypeId& type_id = attr_scidb.getType();
-
-      if (type_id == ::scidb::TID_INT16)
-        ss << cell_it->get_int16(attr_scidb.getName());
-      if (type_id == ::scidb::TID_UINT16)
-        ss << cell_it->get_uint16(attr_scidb.getName());
-      else if (type_id == ::scidb::TID_UINT8)
-        ss << cell_it->get_uint8(attr_scidb.getName());
-      else if (type_id == ::scidb::TID_INT8)
-        ss << std::to_string(cell_it->get_int8(attr_scidb.getName()));
-      else if (type_id == ::scidb::TID_INT32)
-        ss << cell_it->get_int32(attr_scidb.getName());
+      if (attribute.datatype == eows::geoarray::datatype_t::int16_dt)
+        ss << cell_it->get_int16(attribute.name);
+      else if (attribute.datatype == eows::geoarray::datatype_t::uint16_dt)
+        ss << cell_it->get_uint16(attribute.name);
+      else if (attribute.datatype == eows::geoarray::datatype_t::uint8_dt)
+        ss << cell_it->get_uint8(attribute.name);
+      else if (attribute.datatype == eows::geoarray::datatype_t::int8_dt)
+        ss << std::to_string(cell_it->get_int8(attribute.name));
+      else if (attribute.datatype == eows::geoarray::datatype_t::int32_dt)
+        ss << cell_it->get_int32(attribute.name);
 
       // TODO: Remove this check. It should append and remove last char on finish attr
       if (attr_pos + 1 < attributes_size)
@@ -622,10 +616,6 @@ void eows::ogc::wcs::operations::get_coverage::execute()
       throw eows::scidb::query_execution_error("Error in SciDB query result");
 
     boost::shared_ptr<eows::scidb::cell_iterator> cell_it(new eows::scidb::cell_iterator(query_result->array));
-
-    const ::scidb::ArrayDesc& array_desc = query_result->array->getArrayDesc();
-    const ::scidb::Attributes& array_attributes = array_desc.getAttributes(true);
-
     /*
       Defining how to build GetCoverage based in Format.
 
@@ -634,10 +624,10 @@ void eows::ogc::wcs::operations::get_coverage::execute()
     switch(pimpl_->request.format)
     {
       case eows::core::APPLICATION_XML:
-        pimpl_->process_as_document(array, std::move(cell_it), array_attributes, used_extent, dimensions_to_query, attributes_to_query);
+        pimpl_->process_as_document(array, std::move(cell_it), used_extent, dimensions_to_query, attributes_to_query);
         break;
       case eows::core::IMAGE_TIFF:
-        pimpl_->process_as_tiff(std::move(cell_it), array, array_attributes, dimensions_to_query, used_extent, attributes_to_query);
+        pimpl_->process_as_tiff(std::move(cell_it), array, dimensions_to_query, used_extent, attributes_to_query);
         break;
       default:
         throw eows::ogc::not_implemented_error("Format not supported", "NotSupported");


### PR DESCRIPTION
### Overview

This PR introduces a common way to handle both GDAL datatypes and SciDB types using EOWS datatypes_t. This feature enables to re-use the `eows::geoarray::datatype_t`.

- [x] #42 
- [x] #31 

